### PR TITLE
New expanded Sequence support

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/scala/ScalaModule.java
+++ b/src/main/java/com/fasterxml/jackson/module/scala/ScalaModule.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.scala;
 
 import com.fasterxml.jackson.module.scala.deser.ScalaDeserializers;
+import com.fasterxml.jackson.module.scala.deser.SeqTypeModifier;
 import com.fasterxml.jackson.module.scala.ser.ScalaSerializers;
 import org.codehaus.jackson.Version;
 import org.codehaus.jackson.map.*;
@@ -66,6 +67,7 @@ public class ScalaModule extends Module
     {
         context.addDeserializers(new ScalaDeserializers());
         context.addSerializers(new ScalaSerializers());
+        context.addTypeModifier(new SeqTypeModifier());
     }
 
     /*

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaDeserializers.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaDeserializers.scala
@@ -38,8 +38,10 @@ class ScalaDeserializers extends Deserializers {
 									   property: BeanProperty,
 									   elementTypeDeserializer: TypeDeserializer,
 									   elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] = {
-		null
-	}
+    val resolvedDeserializer =
+      Option(elementDeserializer).getOrElse(provider.findValueDeserializer(config,collectionType.containedType(0),property))
+    new SeqDeserializer(collectionType, config, resolvedDeserializer, elementTypeDeserializer)
+  }
 
 	def findEnumDeserializer(beanType: Class[_],
 							 config: DeserializationConfig,
@@ -124,6 +126,6 @@ class ScalaDeserializers extends Deserializers {
 		val contentType = javaType.containedType(0)
 		val contentDeser = provider.findValueDeserializer(config, contentType, property)
 		val valueTypeDeser = null // TODO: will this be a problem?
-		new ScalaListDeserializer(javaType, contentDeser, valueTypeDeser)
+		null //new ScalaListDeserializer(javaType, contentDeser, valueTypeDeser)
 	}
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializer.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializer.scala
@@ -1,0 +1,72 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import org.codehaus.jackson.JsonParser
+import org.codehaus.jackson.`type`.JavaType
+import org.codehaus.jackson.map.{DeserializationConfig, TypeDeserializer, DeserializationContext, JsonDeserializer}
+import java.util.{Iterator, AbstractCollection, ArrayList}
+import collection.mutable
+import collection.immutable.Queue
+import collection.generic.GenericCompanion
+import org.codehaus.jackson.map.deser.{CollectionDeserializer, ContainerDeserializer}
+
+private class BuilderWrapper[E](val builder: mutable.Builder[E, _ <: Seq[E]]) extends AbstractCollection[E] {
+
+  override def add(e: E) = { builder += e; true }
+
+  // Required by AbstractCollection, but the deserializer doesn't care about them.
+  override def iterator(): Iterator[E] = null
+  override def size(): Int = 0
+}
+
+private object SeqDeserializer {
+  // This hurts my eyes, but it's the key component of making the type matching work.
+  // Also, order matters, as derived classes must come before base classes.
+  // TODO: try and make this lookup less painful-looking
+  val COMPANIONS = List[(Class[_],GenericCompanion[collection.Seq])](
+    classOf[mutable.ResizableArray[_]] -> mutable.ResizableArray,
+    classOf[mutable.ArraySeq[_]] -> mutable.ArraySeq,
+    classOf[mutable.IndexedSeq[_]] -> mutable.IndexedSeq,
+    classOf[IndexedSeq[_]] -> IndexedSeq,
+    classOf[Stream[_]] -> Stream,
+    classOf[Queue[_]] -> Queue,
+    classOf[mutable.Queue[_]] -> mutable.Queue,
+    classOf[mutable.MutableList[_]] -> mutable.MutableList,
+    classOf[mutable.LinearSeq[_]] -> mutable.LinearSeq,
+    classOf[mutable.ListBuffer[_]] -> mutable.ListBuffer,
+    classOf[mutable.Buffer[_]] -> mutable.Buffer
+  )
+
+  def companionFor(cls: Class[_]): GenericCompanion[collection.Seq] =
+    COMPANIONS find { _._1.isAssignableFrom(cls) } map { _._2 } getOrElse(Seq)
+
+  def builderFor[A](cls: Class[_]): mutable.Builder[A,Seq[A]] = companionFor(cls).newBuilder[A]
+}
+
+private [deser] class SeqDeserializer(
+    collectionType: JavaType,
+    config: DeserializationConfig,
+    valueDeser: JsonDeserializer[_],
+    valueTypeDeser: TypeDeserializer)
+
+  extends ContainerDeserializer[Seq[AnyRef]](classOf[SeqDeserializer]) {
+
+  // This type is never used because we never let the collection deserializer construct an instance
+  // TODO: Rework BuilderWrapper so it can serve in its place
+  private val dummyCollectionClass =
+    classOf[ArrayList[Object]].asInstanceOf[Class[java.util.Collection[Object]]]
+
+  private val javaContainerType = config.constructType(dummyCollectionClass)
+  private val javaCtor = dummyCollectionClass.getConstructor()
+  private val containerDeserializer =
+    new CollectionDeserializer(javaContainerType,valueDeser.asInstanceOf[JsonDeserializer[AnyRef]],valueTypeDeser,javaCtor)
+
+  override def getContentType = containerDeserializer.getContentType
+
+  override def getContentDeserializer = containerDeserializer.getContentDeserializer
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): Seq[AnyRef] = {
+    val builder = SeqDeserializer.builderFor[AnyRef](collectionType.getRawClass)
+    containerDeserializer.deserialize(jp, ctxt, new BuilderWrapper[AnyRef](builder))
+    builder.result()
+  }
+}

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqTypeModifier.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqTypeModifier.scala
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import org.codehaus.jackson.`type`.JavaType
+import java.lang.reflect.{Type, ParameterizedType}
+import org.codehaus.jackson.map.`type`.{TypeFactory, TypeBindings, SimpleType, TypeModifier}
+
+private [scala] class SeqTypeModifier extends TypeModifier {
+  private val BASE = classOf[Seq[_]]
+  // Workaround for http://jira.codehaus.org/browse/JACKSON-638
+  private def UNKNOWN = SimpleType.construct(classOf[AnyRef])
+
+  def modifyType(originalType: JavaType, jdkType: Type, context: TypeBindings, typeFactory: TypeFactory) =
+    classObjectFor(jdkType) map { cls =>
+      if (BASE.isAssignableFrom(cls)) {
+        val eltType = if (originalType.containedTypeCount() == 1) originalType.containedType(0) else UNKNOWN
+        typeFactory.constructCollectionLikeType(cls, eltType)
+      }
+      else
+        originalType
+    } getOrElse originalType
+
+  private def classObjectFor(jdkType: Type) = jdkType match {
+    case cls: Class[_] => Some(cls)
+    case pt: ParameterizedType => pt.getRawType match {
+      case cls: Class[_] => Some(cls)
+      case _ => None
+    }
+    case _ => None
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/SeqDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/SeqDeserializerTest.scala
@@ -1,0 +1,102 @@
+package com.fasterxml.jackson.module.scala
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.junit.JUnitRunner
+import org.codehaus.jackson.`type`.TypeReference
+import collection.LinearSeq
+import collection.mutable
+import collection.immutable.Queue
+import org.codehaus.jackson.map.ObjectMapper
+
+@RunWith(classOf[JUnitRunner])
+class SeqDeserializerTest extends FlatSpec with ShouldMatchers {
+
+  "An ObjectMapper with the SeqDeserializer" should "deserialize a list into an IndexedSeq" in {
+    // The temporary object is necessary to force the cast back to the concrete type.
+    // Otherwise the value is elided directly to ShouldMatcher, which will take any Seq
+    // TODO: Would the JVM ever elide this anyway?
+    val result = deserializeWithModule(listJson, new TypeReference[IndexedSeq[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable IndexedSeq" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.IndexedSeq[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a Vector" in {
+    val result = deserializeWithModule(listJson, new TypeReference[Vector[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a ResizableArray" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.ResizableArray[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into an ArraySeq" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.ArraySeq[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a LinearSeq" in {
+    val result = deserializeWithModule(listJson, new TypeReference[LinearSeq[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable LinearSeq" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.LinearSeq[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a List" in {
+    val result = deserializeWithModule(listJson, new TypeReference[List[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a Stream" in {
+    val result = deserializeWithModule(listJson, new TypeReference[Stream[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a MutableList" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.MutableList[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into an immutable Queue" in {
+    val result = deserializeWithModule(listJson, new TypeReference[Queue[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable Queue" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.Queue[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable Buffer" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.Buffer[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable ArrayBuffer" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.ArrayBuffer[Int]] {})
+    result should equal (listScala)
+  }
+
+  it should "deserialize a list into a mutable ListBuffer" in {
+    val result = deserializeWithModule(listJson, new TypeReference[mutable.ListBuffer[Int]] {})
+    result should equal (listScala)
+  }
+
+  def deserializeWithModule[T](value: String, valueType: TypeReference[T]) : T = {
+    val mapper = new ObjectMapper()
+    mapper.registerModule(new ScalaModule())
+    mapper.readValue(value, valueType)
+  }
+
+  val listJson =  "[1,2,3,4,5,6]"
+  val listScala = (1 to 6)
+}


### PR DESCRIPTION
Expanded ScalaListDeserializer in to a new SeqDeserializer class, plus a SeqTypeModifier to instruct Jackson to treat sequences as CollectionLike. Tests included.
