### PR TITLE
Adding Set Support

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
@@ -21,6 +21,7 @@ sealed class DefaultScalaModule
      with TupleModule
      with MapModule
      with CaseClassModule
+     with SetModule
 {
   override def getModuleName = "DefaultScalaModule"
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/SetModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/SetModule.scala
@@ -1,0 +1,7 @@
+package com.fasterxml.jackson.module.scala
+
+import com.fasterxml.jackson.module.scala.deser.UnsortedSetDeserializerModule
+
+trait SetModule extends UnsortedSetDeserializerModule {
+  
+}

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -7,13 +7,13 @@ import org.codehaus.jackson.JsonParser
 import org.codehaus.jackson.map.`type`.CollectionLikeType
 import org.codehaus.jackson.map.{DeserializationContext, JsonDeserializer, TypeDeserializer, BeanProperty, BeanDescription, DeserializerProvider, DeserializationConfig, Deserializers}
 
-import collection.mutable
 import collection.generic.GenericCompanion
 import collection.immutable.Queue
 
 import java.util.AbstractCollection
 import org.codehaus.jackson.map.deser.std.{CollectionDeserializer, ContainerDeserializerBase}
 import org.codehaus.jackson.map.deser.ValueInstantiator
+import scala.collection.{immutable, mutable}
 
 private class BuilderWrapper[E](val builder: mutable.Builder[E, _ <: Seq[E]]) extends AbstractCollection[E] {
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -1,0 +1,94 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import org.codehaus.jackson.JsonParser
+import org.codehaus.jackson.map.deser.ValueInstantiator
+import org.codehaus.jackson.map.deser.std.{CollectionDeserializer, ContainerDeserializerBase}
+import scala.collection.generic.GenericCompanion
+import java.util.AbstractCollection
+import scala.collection.{immutable, mutable}
+import com.fasterxml.jackson.module.scala.modifiers.SetTypeModifierModule
+import org.codehaus.jackson.map.`type`.CollectionLikeType
+import org.codehaus.jackson.map.{BeanDescription, BeanProperty, DeserializerProvider, DeserializationContext, TypeDeserializer, JsonDeserializer, DeserializationConfig, Deserializers}
+
+private class SetBuilderWrapper[E](val builder: mutable.Builder[E, _ <: collection.Set[E]]) extends AbstractCollection[E] {
+
+  override def add(e: E) = { builder += e; true }
+
+  // Required by AbstractCollection, but the deserializer doesn't care about them.
+  def iterator() = null
+  def size() = 0
+}
+
+private object UnsortedSetDeserializer {
+  // This is a key component of making the type matching work.
+  // Order matters, as derived classes must come before base classes.
+  // TODO: try and make this lookup less painful-looking
+  val COMPANIONS = List[(Class[_], GenericCompanion[collection.Set])](
+    classOf[mutable.LinkedHashSet[_]] -> mutable.LinkedHashSet,
+    classOf[mutable.HashSet[_]] -> mutable.HashSet,
+    classOf[mutable.Set[_]] -> mutable.Set,
+    classOf[immutable.ListSet[_]] -> immutable.ListSet,
+    classOf[immutable.HashSet[_]] -> immutable.HashSet,
+    classOf[immutable.Set[_]] -> immutable.Set
+  )
+
+  def companionFor(cls: Class[_]): GenericCompanion[collection.Set] =
+    COMPANIONS find { _._1.isAssignableFrom(cls) } map { _._2 } getOrElse (Set)
+
+  def builderFor[A](cls: Class[_]): mutable.Builder[A, collection.Set[A]] = companionFor(cls).newBuilder[A]
+}
+
+private class UnsortedSetDeserializer(collectionType: CollectionLikeType,
+                                      config: DeserializationConfig,
+                                      valueDeser: JsonDeserializer[_],
+                                      valueTypeDeser: TypeDeserializer)
+
+  extends ContainerDeserializerBase[collection.Set[_]](classOf[UnsortedSetDeserializer]) {
+
+  private val javaContainerType = config.constructType(classOf[SetBuilderWrapper[AnyRef]])
+
+  private val instantiator = new ValueInstantiator {
+    def getValueTypeDesc = collectionType.getRawClass.getCanonicalName
+
+    override def canCreateUsingDefault = true
+
+    override def createUsingDefault =
+      new SetBuilderWrapper[AnyRef](UnsortedSetDeserializer.builderFor[AnyRef](collectionType.getRawClass))
+  }
+  private val containerDeserializer =
+    new CollectionDeserializer(javaContainerType, valueDeser.asInstanceOf[JsonDeserializer[AnyRef]], valueTypeDeser, instantiator)
+
+  override def getContentType = containerDeserializer.getContentType
+
+  override def getContentDeserializer = containerDeserializer.getContentDeserializer
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): collection.Set[_] =
+    containerDeserializer.deserialize(jp, ctxt) match {
+      case wrapper: SetBuilderWrapper[_] => wrapper.builder.result()
+    }
+}
+
+private object UnsortedSetDeserializerResolver extends Deserializers.Base {
+
+  override def findCollectionLikeDeserializer(collectionType: CollectionLikeType,
+                                              config: DeserializationConfig,
+                                              provider: DeserializerProvider,
+                                              beanDesc: BeanDescription,
+                                              property: BeanProperty,
+                                              elementTypeDeserializer: TypeDeserializer,
+                                              elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] = {
+    val rawClass = collectionType.getRawClass
+
+    if (classOf[collection.Set[_]].isAssignableFrom(rawClass)) {
+      val resolvedDeserializer =
+        Option(elementDeserializer).getOrElse(provider.findValueDeserializer(config, collectionType.containedType(0), property))
+      new UnsortedSetDeserializer(collectionType, config, resolvedDeserializer, elementTypeDeserializer)
+    } else {
+      null
+    }
+  }
+}
+
+trait UnsortedSetDeserializerModule extends SetTypeModifierModule {
+  this += UnsortedSetDeserializerResolver
+}

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/SetTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/SetTypeModifierModule.scala
@@ -1,0 +1,11 @@
+package com.fasterxml.jackson.module.scala.modifiers
+
+import com.fasterxml.jackson.module.scala.JacksonModule
+
+private object SetTypeModifier extends CollectionLikeTypeModifier {
+  val BASE = classOf[collection.Set[Any]]
+}
+
+trait SetTypeModifierModule extends JacksonModule {
+  this += SetTypeModifier
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import scala.collection.{immutable, mutable}
+
+@RunWith(classOf[JUnitRunner])
+class UnsortedSetDeserializerTest extends DeserializerTest with FlatSpec with ShouldMatchers {
+
+  lazy val module = new UnsortedSetDeserializerModule {}
+
+  "An ObjectMapper with the SetDeserializerModule" should "deserialize an object into a Set" in {
+    val result = deserialize[Set[String]](setJson)
+    result should equal(setScala)
+  }
+
+  it should "deserialize an object into a HashSet" in {
+    val result = deserialize[immutable.HashSet[String]](setJson)
+    result should equal(setScala)
+  }
+
+  it should "deserialize an object into a mutable HashSet" in {
+    val result = deserialize[mutable.HashSet[String]](setJson)
+    result should equal(setScala)
+  }
+
+  it should "deserialize an object into a LinkedHashSet" in {
+    val result = deserialize[mutable.LinkedHashSet[String]](setJson)
+    result should equal(setScala)
+  }
+
+  it should "deserialize an object with variable value types into a variable UnsortedSet" in {
+    val result = deserialize[Set[Any]](variantSetJson)
+    result should equal(variantSetScala)
+  }
+  
+  it should "deserialize an object into a ListSet" in {
+    val result = deserialize[immutable.ListSet[String]](setJson)
+    result should equal (setScala)
+  }
+
+  val setJson = """[ "one", "two" ]"""
+  val setScala = Set("one", "two")
+  val variantSetJson = """[ "1", 2 ]"""
+  val variantSetScala = Set[Any]("1", 2)
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.matchers.ShouldMatchers
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.fasterxml.jackson.module.scala.JacksonModule
-import collection.Iterator
 import org.codehaus.jackson.map.JsonMappingException
+import scala.collection.{mutable, immutable, Iterator}
 
 /**
  * Undocumented class.
@@ -28,8 +28,28 @@ class IterableSerializerTest extends SerializerTest with FlatSpec with ShouldMat
     serialize(Seq(1,2,3)) should be ("[1,2,3]")
   }
 
-  it should "serialize a Set[Int]" in {
-    serialize(Set(1,2,3)) should be ("[1,2,3]")
+  it should "serialize an immutable Set[Int]" in {
+    serialize(immutable.Set(1,2,3)) should (matchUnorderedSet)
+  }
+
+  it should "serialize an immutable HashSet[Int]" in {
+    serialize(immutable.HashSet(1,2,3)) should (matchUnorderedSet)
+  }
+
+  it should "serialize an immutable ListSet[Int]" in {
+    serialize(immutable.ListSet(1,2,3)) should (matchUnorderedSet)
+  }
+
+  it should "serialize a mutable Set[Int]" in {
+    serialize(mutable.Set(1,2,3)) should matchUnorderedSet
+  }
+  
+  it should "serialize a mutable HashSet[Int]" in {
+    serialize(mutable.HashSet(1,2,3)) should matchUnorderedSet
+  }
+
+  it should "serialize a mutable LinkedHashSet[Int]" in {
+    serialize(mutable.LinkedHashSet(1,2,3)) should matchUnorderedSet
   }
 
   it should "not serialize a Map[Int]" in {
@@ -38,4 +58,12 @@ class IterableSerializerTest extends SerializerTest with FlatSpec with ShouldMat
     }
   }
 
+  val matchUnorderedSet = {
+    be ("[1,2,3]") or
+    be ("[1,3,2]") or
+    be ("[2,1,3]") or
+    be ("[2,3,1]") or
+    be ("[3,1,2]") or
+    be ("[3,2,1]")
+  }
 }


### PR DESCRIPTION
'Set's already naturally serialize as 'Seq'. This adds in the support for deserializing 'Set's.

This code is extremely similar to the SeqDeserializer, and if you want I could probably convert it to a generic class where the implementation for Seq and Set would be minimal extensions.

Additionally, I was thinking about your comment:
  // This hurts my eyes, but it's the key component of making the type matching work.
  // Also, order matters, as derived classes must come before base classes.
  // TODO: try and make this lookup less painful-looking

One solution that fixes the ordering issue would be to generate a dependency graph (edges built via the Class.isAssignableFrom(Class) method) and build a topological sort. And, I imagine it should be possible to write a generic register method that uses Manifests to infer which class a specific GenericCompanion would build.

I'd be willing to do any of these things if they interest you.
