### PR TITLE
The module should handle parameterized case classes.

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerModule.scala
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.module.scala.JacksonModule
-import org.scalastuff.scalabeans.Preamble._
 import org.codehaus.jackson.map.introspect.{AnnotatedField, AnnotatedConstructor, AnnotatedParameter, NopAnnotationIntrospector}
 import org.scalastuff.scalabeans.{DeserializablePropertyDescriptor, ConstructorParameter}
+import com.fasterxml.jackson.module.scala.util.ScalaBeansUtil
 
 private object CaseClassAnnotationIntrospector extends NopAnnotationIntrospector {
   lazy val PRODUCT = classOf[Product]
@@ -22,9 +22,9 @@ private object CaseClassAnnotationIntrospector extends NopAnnotationIntrospector
     val cls = af.getDeclaringClass
     if (!maybeIsCaseClass(cls)) null
     else {
-      val descriptor = descriptorOf(cls)
+      val properties = ScalaBeansUtil.propertiesOf(cls)
 
-      descriptor.properties.find {
+      properties.find {
         case dp: DeserializablePropertyDescriptor => af.getName.equals(dp.name)
         case _ => false
       } map (_.name) getOrElse null
@@ -46,9 +46,9 @@ private object CaseClassAnnotationIntrospector extends NopAnnotationIntrospector
     val cls = param.getDeclaringClass
     if (!maybeIsCaseClass(cls)) null
     else {
-      val descriptor = descriptorOf(cls)
+      val properties = ScalaBeansUtil.propertiesOf(cls)
 
-      descriptor.properties.find {
+      properties.find {
         case cp: ConstructorParameter => cp.index == param.getIndex
         case _ => false
       }.map(_.name) getOrElse null

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
@@ -4,10 +4,10 @@ import collection.JavaConverters._
 import com.fasterxml.jackson.module.scala.JacksonModule
 import org.codehaus.jackson.map.SerializationConfig
 import org.codehaus.jackson.map.ser.{BeanSerializerModifier, BeanPropertyWriter}
-import org.scalastuff.scalabeans.Preamble._
 import org.scalastuff.scalabeans.ConstructorParameter
 import org.codehaus.jackson.map.introspect.{JacksonAnnotationIntrospector, AnnotatedMethod, BasicBeanDescription}
 import java.util.{ArrayList, List => juList}
+import com.fasterxml.jackson.module.scala.util.ScalaBeansUtil
 
 private object CaseClassBeanSerializerModifier extends BeanSerializerModifier {
   private val PRODUCT = classOf[Product]
@@ -18,7 +18,7 @@ private object CaseClassBeanSerializerModifier extends BeanSerializerModifier {
                                 beanProperties: juList[BeanPropertyWriter]): juList[BeanPropertyWriter] = {
     val list = for {
       cls <- Option(beanDesc.getBeanClass).toSeq if (PRODUCT.isAssignableFrom(cls))
-      prop <- descriptorOf(cls).properties
+      prop <- ScalaBeansUtil.propertiesOf(cls)
       // Not completely happy with this test. I'd rather check the PropertyDescription
       // to see if it's a field or a method, but ScalaBeans doesn't expose that as yet.
       // I'm not sure if it truly matters as Scala generates method accessors for fields.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/ScalaBeansUtil.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/ScalaBeansUtil.scala
@@ -1,0 +1,26 @@
+package com.fasterxml.jackson.module.scala.util
+
+import org.scalastuff.scalabeans.types.ScalaType
+import org.scalastuff.scalabeans.sig.{Mirror, ClassDeclExtractor}
+import org.scalastuff.scalabeans.PropertyDescriptor
+import org.scalastuff.scalabeans.Preamble._
+
+private abstract class ScalaTypeImpl(val erasure: Class[_], val arguments: ScalaType*) extends ScalaType
+
+object ScalaBeansUtil {
+  def propertiesOf(cls: Class[_]): Seq[PropertyDescriptor] = {
+    val anyType = scalaTypeOf(classOf[Any])
+    val scalaType = scalaTypeOf(cls)
+
+    val extracted = for {
+      top <- ClassDeclExtractor.extract(scalaType.erasure)
+      classDecl <- top.headOption
+      if classDecl.isInstanceOf[Mirror.ClassDecl]
+    } yield {
+      val args = classDecl.asInstanceOf[Mirror.ClassDecl].typeParameters.map(_ => anyType)
+      new ScalaTypeImpl(cls, args: _*) {}
+    }
+
+    descriptorOf(extracted.get).properties
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -8,18 +8,16 @@ import org.junit.runner.RunWith
 import org.codehaus.jackson.annotate.JsonProperty
 import org.codehaus.jackson.map.JsonMappingException
 
-case class CaseClassConstructorTest(intValue: Int, stringValue: String) {
-
-}
+case class CaseClassConstructorTest(intValue: Int, stringValue: String)
 
 case class CaseClassPropertiesTest() {
   var intProperty: Int = 0
   var stringProperty: String = null
 }
 
-case class CaseClassJacksonAnnotationTest(@JsonProperty("foo") oof:String, bar: String) {
+case class CaseClassJacksonAnnotationTest(@JsonProperty("foo") oof:String, bar: String)
 
-}
+case class GenericCaseClassTest[T](data: T)
 
 @RunWith(classOf[JUnitRunner])
 class CaseClassDeserializerTest extends DeserializerTest with FlatSpec with ShouldMatchers {
@@ -46,5 +44,10 @@ class CaseClassDeserializerTest extends DeserializerTest with FlatSpec with Shou
     intercept[JsonMappingException] {
       deserialize[List[_]]("""{"foo":"foo","bar":"bar"}""")
     }
+  }
+
+  it should "deserialize a generic case class" in {
+    val result = GenericCaseClassTest(42)
+    deserialize[GenericCaseClassTest[Int]]("""{"data":42}""") should be (result)
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.ShouldMatchers
 import com.fasterxml.jackson.module.scala.JacksonModule
 import org.codehaus.jackson.annotate.{JsonIgnoreProperties, JsonProperty}
 
-case class CaseClassConstructorTest(intValue: Int, stringValue: String) { }
+case class CaseClassConstructorTest(intValue: Int, stringValue: String)
 
 case class CaseClassValTest() {
   val intVal: Int = 1
@@ -23,9 +23,9 @@ case class CaseClassMixedTest(intValue: Int) {
   val strVal: String = "foo"
 }
 
-case class CaseClassJacksonAnnotationTest(@JsonProperty("foo") oof:String, bar: String) {
+case class CaseClassJacksonAnnotationTest(@JsonProperty("foo") oof:String, bar: String)
 
-}
+case class GenericCaseClassTest[T](data: T)
 
 @JsonIgnoreProperties(Array("ignore"))
 case class CaseClassJacksonIgnorePropertyTest(ignore:String, test:String)
@@ -72,6 +72,12 @@ class CaseClassSerializerTest extends SerializerTest with FlatSpec with ShouldMa
   it should "serialize a case class with ignore property annotations" in {
     serialize(CaseClassJacksonIgnorePropertyTest("ignore", "test")) should (
       equal("""{"test":"test"}""")
+      )
+  }
+
+  it should "seralize a generic case class" in {
+    serialize(GenericCaseClassTest(42)) should (
+      equal("""{"data":42}""")
       )
   }
 }


### PR DESCRIPTION
But it doesn't. It throws an out of bounds exception when trying to match the scala type up with the class description. Since this module only cares about the scalabean descriptor's properties it was harmless =) (I hope).
