### PR TITLE
Issue #38 - Honor PropertyNamingStrategy during serialization

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
@@ -6,7 +6,7 @@ import java.{util => ju}
 
 import org.scalastuff.scalabeans.ConstructorParameter
 
-import com.fasterxml.jackson.databind.{BeanDescription, SerializationConfig};
+import com.fasterxml.jackson.databind.{BeanDescription, PropertyNamingStrategy, SerializationConfig};
 import com.fasterxml.jackson.databind.ser.{BeanPropertyWriter, BeanSerializerModifier};
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.util.SimpleBeanPropertyDefinition
@@ -40,9 +40,13 @@ private object CaseClassBeanSerializerModifier extends BeanSerializerModifier {
 
   private def asWriter(config: SerializationConfig, beanDesc: BeanDescription, member: AnnotatedMethod, primaryName: Option[String] = None) = {
     val javaType = config.getTypeFactory.constructType(member.getGenericType)
-    val name = primaryName.getOrElse(member.getName)
+    val name = maybeTranslateName(config, member, primaryName.getOrElse(member.getName))
     val propDef = new SimpleBeanPropertyDefinition(member, name)
     new BeanPropertyWriter(propDef, member, null, javaType, null, null, null, false, null)
+  }
+
+  private def maybeTranslateName(config: SerializationConfig, member: AnnotatedMethod, name: String) = {
+    Option(config.getPropertyNamingStrategy).map(_.nameForGetterMethod(config, member, name)).getOrElse(name)
   }
 
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.matchers.ShouldMatchers
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonIgnoreProperties, JsonProperty}
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
 
 case class ConstructorTestCaseClass(intValue: Int, stringValue: String)
 
@@ -44,6 +45,7 @@ case class NonNullCaseClass1(@JsonInclude(JsonInclude.Include.NON_NULL) foo: Opt
 
 case class NonNullCaseClass2(foo: Option[String])
 
+case class MixedPropertyNameStyleCaseClass(camelCase: Int, snake_case: Int, alllower: Int, ALLUPPER: Int, anID: Int)
 
 @RunWith(classOf[JUnitRunner])
 class CaseClassSerializerTest extends SerializerTest with FlatSpec with ShouldMatchers {
@@ -115,4 +117,15 @@ class CaseClassSerializerTest extends SerializerTest with FlatSpec with ShouldMa
     val o = NonNullCaseClass2(None)
     nonNullMapper.writeValueAsString(o) should be ("{}")
   }
+
+  def propertyNamingStrategyMapper = new ObjectMapper() {
+    registerModule(module)
+    setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+  }
+
+  it should "honor the property naming strategy" in {
+    val o = MixedPropertyNameStyleCaseClass(42, 42, 42, 42, 42)
+    propertyNamingStrategyMapper.writeValueAsString(o) should be("""{"camel_case":42,"snake_case":42,"alllower":42,"allupper":42,"an_id":42}""")
+  }
+
 }


### PR DESCRIPTION
This is my first pull request, lemme know if I am not following unspoken customs :) Also, let me know if an alternate approach to the issue is desirable.

https://github.com/FasterXML/jackson-module-scala/issues/38
-Updated CaseClassSerializer to respect the PropertyNamingStrategy if defined
-Added test case
