### PR TITLE
Create a companion sorter to prevent accidental human error. 

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -15,6 +15,7 @@ import collection.immutable.Queue
 
 import java.util.AbstractCollection
 import scala.collection.mutable
+import com.fasterxml.jackson.module.scala.util.CompanionSorter
 
 private class BuilderWrapper[E](val builder: mutable.Builder[E, _ <: Seq[E]]) extends AbstractCollection[E] {
 
@@ -26,22 +27,19 @@ private class BuilderWrapper[E](val builder: mutable.Builder[E, _ <: Seq[E]]) ex
 }
 
 private object SeqDeserializer {
-  // This hurts my eyes, but it's the key component of making the type matching work.
-  // Also, order matters, as derived classes must come before base classes.
-  // TODO: try and make this lookup less painful-looking
-  val COMPANIONS = List[(Class[_],GenericCompanion[collection.Seq])](
-    classOf[mutable.ResizableArray[_]] -> mutable.ResizableArray,
-    classOf[mutable.ArraySeq[_]] -> mutable.ArraySeq,
-    classOf[mutable.IndexedSeq[_]] -> mutable.IndexedSeq,
-    classOf[IndexedSeq[_]] -> IndexedSeq,
-    classOf[Stream[_]] -> Stream,
-    classOf[Queue[_]] -> Queue,
-    classOf[mutable.Queue[_]] -> mutable.Queue,
-    classOf[mutable.MutableList[_]] -> mutable.MutableList,
-    classOf[mutable.LinearSeq[_]] -> mutable.LinearSeq,
-    classOf[mutable.ListBuffer[_]] -> mutable.ListBuffer,
-    classOf[mutable.Buffer[_]] -> mutable.Buffer
-  )
+  val COMPANIONS = new CompanionSorter[collection.Seq]()
+    .add(IndexedSeq)
+    .add(mutable.ArraySeq)
+    .add(mutable.Buffer)
+    .add(mutable.IndexedSeq)
+    .add(mutable.LinearSeq)
+    .add(mutable.ListBuffer)
+    .add(mutable.MutableList)
+    .add(mutable.Queue)
+    .add(mutable.ResizableArray)
+    .add(Queue)
+    .add(Stream)
+    .toList
 
   def companionFor(cls: Class[_]): GenericCompanion[collection.Seq] =
     COMPANIONS find { _._1.isAssignableFrom(cls) } map { _._2 } getOrElse(Seq)

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/CompanionSorter.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/CompanionSorter.scala
@@ -1,0 +1,63 @@
+package com.fasterxml.jackson.module.scala.util
+
+import collection.mutable.{ArrayBuffer, ListBuffer}
+import collection.GenTraversable
+import collection.generic.GenericCompanion
+
+/**
+ * The CompanionSorter performs a topological sort on class hierarchy to ensure that the most specific builders
+ * get registered first.
+ */
+class CompanionSorter[CC[X] <: GenTraversable[X]] {
+  type HKClassManifest[CC2[_]] = ClassManifest[CC2[_]]
+
+  private[this] val companions = new ArrayBuffer[(Class[_], GenericCompanion[CC])]()
+
+  def add[T[X] <: CC[X] : HKClassManifest](companion: GenericCompanion[T]): CompanionSorter[CC] = {
+    companions += implicitly[HKClassManifest[T]].erasure -> companion
+    this
+  }
+
+  def toList: List[(Class[_], GenericCompanion[CC])] = {
+    val cs = companions.toArray
+    val output = new ListBuffer[(Class[_], GenericCompanion[CC])]()
+
+    val remaining = cs.map(_ => 1)
+    val adjMatrix = Array.ofDim[Int](cs.length, cs.length)
+
+    // Build the adjacency matrix. Only mark the in-edges.
+    for (i <- 0 until cs.length; j <- 0 until cs.length) {
+      val (ic, _) = cs(i)
+      val (jc, _) = cs(j)
+
+      if (i != j && ic.isAssignableFrom(jc)) {
+        adjMatrix(i)(j) = 1
+      }
+    }
+
+    // While we haven't removed every node, remove all nodes with 0 degree in-edges.
+    while (output.length < cs.length) {
+      val startLength = output.length
+
+      for (i <- 0 until cs.length) {
+        if (remaining(i) == 1 && dotProduct(adjMatrix(i), remaining) == 0) {
+          output += companions(i)
+          remaining(i) = 0
+        }
+      }
+
+      // If we couldn't remove any nodes, it means we've found a cycle. Realistically this should never happen.
+      if (output.length == startLength) {
+        throw new IllegalStateException("Companions contain a cycle.")
+      }
+    }
+
+    output.toList
+  }
+
+  private[this] def dotProduct(a: Array[Int], b: Array[Int]): Int = {
+    if (a.length != b.length) throw new IllegalArgumentException()
+
+    (0 until a.length).map(i => a(i) * b(i)).sum
+  }
+}


### PR DESCRIPTION
I promised you I would do this for you some day, and hopefully later is better than never =).

The two goals were 1) address that you felt the code looked like a hack, and 2) prevent any future accidental human error (since it's non-obvious what the hierarchy is if you haven't memorized those things yet). Note that both companion lists are adding each companion object in alphabetical order (partly to demonstrate that the topological sort works, and partly to do something that's maintainable).

I'd be willing to change anything that you'd like to see a little different. This was my first cut at it and it definitely demonstrates what I had hoped it would, but I haven't written topological sort in a long time.
