### PR TITLE
JsonTypeInfo is now also picked up when it is not the root object

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerModule.scala
@@ -9,7 +9,7 @@ import org.scalastuff.scalabeans.ConstructorParameter
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonIgnore}
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 import com.fasterxml.jackson.databind.{PropertyName, BeanDescription, SerializationConfig}
-import com.fasterxml.jackson.databind.ser.{BeanPropertyWriter, BeanSerializerModifier}
+import com.fasterxml.jackson.databind.ser.{BeanSerializerFactory, BeanPropertyWriter, BeanSerializerModifier}
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.util.SimpleBeanPropertyDefinition
 import com.fasterxml.jackson.module.scala.JacksonModule
@@ -52,7 +52,11 @@ private object CaseClassBeanSerializerModifier extends BeanSerializerModifier {
     val defaultName = NameTransformer.decode(member.getName)
     val name = maybeTranslateName(config, member, primaryName.map(_.toString).getOrElse(defaultName))
     val propDef = new SimpleBeanPropertyDefinition(member, name)
-    new BeanPropertyWriter(propDef, member, null, javaType, null, null, null, suppressNulls, null)
+
+    val jsf = BeanSerializerFactory.instance
+    val typeSer = jsf.findPropertyTypeSerializer(javaType, config, member)
+
+    new BeanPropertyWriter(propDef, member, null, javaType, null, typeSer, null, suppressNulls, null)
   }
 
   private def maybeTranslateName(config: SerializationConfig, member: AnnotatedMethod, name: String) = {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.ShouldMatchers
 
 
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonIgnoreProperties, JsonProperty}
+import com.fasterxml.jackson.annotation.{JsonTypeInfo, JsonInclude, JsonIgnoreProperties, JsonProperty}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 
@@ -42,6 +42,10 @@ case class CaseClassWithCompanion(intValue: Int)
 @JsonIgnoreProperties(Array("ignore"))
 case class JacksonIgnorePropertyTestCaseClass(ignore:String, test:String)
 
+@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="class")
+case class JsonTypeInfoCaseClass(intValue: Int)
+
+case class CaseClassContainingJsonTypeInfoCaseClass(c: JsonTypeInfoCaseClass)
 
 case class NonNullCaseClass1(@JsonInclude(JsonInclude.Include.NON_NULL) foo: String)
 
@@ -135,6 +139,18 @@ class CaseClassSerializerTest extends SerializerTest with FlatSpec with ShouldMa
   it should "honor the property naming strategy" in {
     val o = MixedPropertyNameStyleCaseClass(42, 42, 42, 42, 42)
     propertyNamingStrategyMapper.writeValueAsString(o) should be("""{"camel_case":42,"snake_case":42,"alllower":42,"allupper":42,"an_id":42}""")
+  }
+
+  it should "serialize a case class with JsonTypeInfo" in {
+    serialize(JsonTypeInfoCaseClass(1)) should (
+      equal("""{"class":"com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}""")
+    )
+  }
+
+  it should "serialize a case class containing a case class with JsonTypeInfo" in {
+    serialize(CaseClassContainingJsonTypeInfoCaseClass(JsonTypeInfoCaseClass(1))) should (
+      equal("""{"c":{"class":"com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}}""")
+    )
   }
 
 }


### PR DESCRIPTION
This is a fix for issue #51. I added 2 test cases. One of them - "serialize a case class containing a case class with JsonTypeInfo" - fails without the patch.

Not sure whether there are better ways to get the required `typeSer`. Please see note in the commit. 
