### PR TITLE
Test deserialization with PropertyNamingStrategies

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategy
 
 case class ConstructorTestCaseClass(intValue: Int, stringValue: String)
 
@@ -22,6 +24,8 @@ case class JacksonAnnotationTestCaseClass(@JsonProperty("foo") oof:String, bar: 
 case class GenericTestCaseClass[T](data: T)
 
 case class UnicodeNameCaseClass(`winning-id`: Int, name: String)
+
+case class MixedPropertyNameStyleCaseClass(camelCase: Int, snake_case: Int, alllower: Int, ALLUPPER: Int, anID: Int)
 
 @RunWith(classOf[JUnitRunner])
 class CaseClassDeserializerTest extends DeserializerTest with FlatSpec with ShouldMatchers {
@@ -59,4 +63,15 @@ class CaseClassDeserializerTest extends DeserializerTest with FlatSpec with Shou
     val result = GenericTestCaseClass(42)
     deserialize[GenericTestCaseClass[Int]]("""{"data":42}""") should be (result)
   }
+
+  def propertyNamingStrategyMapper = new ObjectMapper() {
+    registerModule(module)
+    setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+  }
+
+  it should "honor the property naming strategy" in {
+    val result = MixedPropertyNameStyleCaseClass(42, 42, 42, 42, 42)
+    propertyNamingStrategyMapper.readValue("""{"camel_case":42,"snake_case":42,"alllower":42,"allupper":42,"an_id":42}""", classOf[MixedPropertyNameStyleCaseClass]) should be (result)
+  }
+
 }


### PR DESCRIPTION
In older versions of the module, this test failed, although it currently passes.  This is to ensure we don't regress in the future.

Old failure mode:

[info] - should honor the property naming strategy **\* FAILED ***
[info]   com.fasterxml.jackson.databind.JsonMappingException: Could not find creator property with name 'camel_case'
[info]  at [Source: java.io.StringReader@30504d67; line: 1, column: 1]
[info]   at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
[info]   at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:608)
[info]   at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.addBeanProps(BeanDeserializerFactory.java:551)
[info]   at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildBeanDeserializer(BeanDeserializerFactory.java:267)
[info]   at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:171)
[info]   at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:388)
[info]   at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:264)
[info]   at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
[info]   at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:143)
[info]   at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:342)
[info]   ...
