### PR TITLE
Option JsonSchema generation with jackson-module-jsonSchema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "2.0.M5b" % "test",
     "junit" % "junit" % "4.11" % "test",
     "com.novocode" % "junit-interface" % "0.10-M3" % "test",
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.1.2" % "test"
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.1.2" % "test",
+    "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % "2.2.0"
 )
 
 // publishing

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerTest.scala
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonInclude}
 import annotation.target.getter
 import com.fasterxml.jackson.databind.annotation.{JsonSerialize, JsonDeserialize}
+import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper
 
 class NonEmptyOptions {
 
@@ -74,6 +75,15 @@ class OptionSerializerTest extends SerializerTest with FlatSpec with ShouldMatch
 
   it should "generate correct schema for options" in {
     val schema = mapper.generateJsonSchema(classOf[OptionSchema])
+    val schemaString = mapper.writeValueAsString(schema)
+    schemaString should be === ("""{"type":"object","properties":{"stringValue":{"type":"string","required":false}}}""")
+  }
+
+  it should "generate correct schema for options using the new jsonSchema jackson module" in {
+    val visitor = new SchemaFactoryWrapper()
+    mapper.acceptJsonFormatVisitor(mapper.constructType(classOf[OptionSchema]), visitor)
+
+    val schema = visitor.finalSchema()
     val schemaString = mapper.writeValueAsString(schema)
     schemaString should be === ("""{"type":"object","properties":{"stringValue":{"type":"string","required":false}}}""")
   }


### PR DESCRIPTION
We have been trying to use [jackson-module-jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema) in combination with `jackson-module-scala` to generate JSON Schema from Scala case classes.

We have found it to work pretty well so far, however it doesn't render Options correctly. They come out as `{"type":"any"}`.

This pull request contains a failing test showing the problem. I don't have a fix and I don't know enough to be able to determine if this is a problem in `jackson-module-scala` or `jackson-module-jsonSchema`, but and happy to do some further digging if required.

```
"...stringValue":{"type":"[any"]}}}" was not equal to "...stringValue":{"type":"[string","required":false]}}}" (OptionSerializerTest.scala:88)
```
