### PR TITLE
treat Option as CollectionLike in ScalaObjectMapper

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
@@ -64,7 +64,7 @@ trait ScalaObjectMapper {
       } else if(isCollectionLike(clazz)) {
         val typeArguments = m.typeArguments.map(constructType(_)).toArray
         if(typeArguments.length != 1) {
-          throw new IllegalArgumentException("Need exactly 1 type parameter for iterable like types ("+clazz.getName+")")
+          throw new IllegalArgumentException("Need exactly 1 type parameter for collection like types ("+clazz.getName+")")
         }
         getTypeFactory.constructCollectionLikeType(clazz, typeArguments(0))
       } else {
@@ -309,8 +309,9 @@ trait ScalaObjectMapper {
   }
 
   private val ITERABLE = classOf[collection.Iterable[_]]
+  private val OPTION = classOf[Option[_]]
   private def isCollectionLike(c: Class[_]): Boolean = {
-    ITERABLE.isAssignableFrom(c)
+    ITERABLE.isAssignableFrom(c) || OPTION.isAssignableFrom(c)
   }
 
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
@@ -196,6 +196,12 @@ class ScalaObjectMapperTest extends FlatSpec with ShouldMatchers {
     assert(result.isInstanceOf[collection.Map[_, _]])
   }
 
+  it should "read a option values from a JSON array" in {
+    val result = mapper.readValue[List[Option[String]]](toplevelOptionArrayJson)
+    result(0) should equal(Some("some"))
+    result(1) should equal(None)
+  }
+
   // No tests for the following functions:
   //  def readValue[T: Manifest](src: File): T
   //  def readValue[T: Manifest](src: URL): T
@@ -208,5 +214,6 @@ class ScalaObjectMapperTest extends FlatSpec with ShouldMatchers {
   private val genericTwoFieldJson = """{"first":"firstVal","second":"secondVal"}"""
   private val genericMixedFieldJson = """{"first":"firstVal","second":2}"""
   private val toplevelArrayJson = """[{"t":42},{"t":31}]"""
+  private val toplevelOptionArrayJson = """["some",null]"""
 
 }


### PR DESCRIPTION
This will ensure that the custom OptionDeserializer is always used when deserializing Options.
Right now when `List[Option[_]]` is deserialized, the Option class is treated as a "simple" type in the constructed `JavaType` and thus a generic JSON Deserializer is used rather than `OptionDeserializer`.
Note that the new test will NOT pass until a jackson-databind dependency with https://github.com/FasterXML/jackson-databind/pull/407 is used
