### PR TITLE
Use type information to deser Option

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
@@ -2,7 +2,9 @@ package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.core.JsonParser;
 
-import com.fasterxml.jackson.databind._;
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+;
 import com.fasterxml.jackson.databind.jsontype.{TypeDeserializer};
 
 import com.fasterxml.jackson.databind.`type`.CollectionLikeType;
@@ -10,17 +12,56 @@ import com.fasterxml.jackson.databind.`type`.CollectionLikeType;
 import com.fasterxml.jackson.module.scala.modifiers.OptionTypeModifierModule
 import deser.{ResolvableDeserializer, ContextualDeserializer, Deserializers}
 
-private class OptionDeserializer(elementType: JavaType, var deser: JsonDeserializer[_])
-  extends JsonDeserializer[Option[AnyRef]] with ContextualDeserializer {
+private class OptionDeserializer(elementType: JavaType,
+                                 valueTypeDeser: Option[TypeDeserializer],
+                                 beanProperty: Option[BeanProperty],
+                                 elementDeser: Option[JsonDeserializer[_]])
+  extends StdDeserializer[Option[AnyRef]](classOf[Option[AnyRef]]) with ContextualDeserializer {
   
   override def createContextual(ctxt: DeserializationContext, property: BeanProperty): JsonDeserializer[_] = {
-    val cd = ctxt.findContextualValueDeserializer(elementType, property)
-    if (cd != null) new OptionDeserializer(elementType, cd)
+    val typeDeser = valueTypeDeser.map(_.forProperty(property))
+    val deser: Option[JsonDeserializer[_]] =
+      (for {
+        p <- Option(property)
+        m <- Option(p.getMember)
+        deserDef <- Option(ctxt.getAnnotationIntrospector.findContentDeserializer(m))
+      } yield ctxt.deserializerInstance(m, deserDef)).orElse(elementDeser)
+    val deser1: Option[JsonDeserializer[_]] = Option(findConvertingContentDeserializer(ctxt, property, deser.orNull))
+    val deser2: Option[JsonDeserializer[_]] = if (deser1.isEmpty) {
+      if (hasContentTypeAnnotation(ctxt, property)) {
+        Option(ctxt.findContextualValueDeserializer(elementType, property))
+      } else {
+        deser1
+      }
+    } else {
+      Option(ctxt.handleSecondaryContextualization(deser1.get, property))
+    }
+    if (deser2 != elementDeser || property != beanProperty.orNull || valueTypeDeser != typeDeser)
+      new OptionDeserializer(elementType, typeDeser, Option(property), deser2.asInstanceOf[Option[JsonDeserializer[AnyRef]]])
     else this
   }
 
-  override def deserialize(jp: JsonParser, ctxt: DeserializationContext) =
-    Option(deser.deserialize(jp, ctxt)).asInstanceOf[Option[AnyRef]]
+  def hasContentTypeAnnotation(ctxt: DeserializationContext, property: BeanProperty) = (for {
+    p <- Option(property)
+    intr <- Option(ctxt.getAnnotationIntrospector)
+  } yield {
+    intr.findDeserializationContentType(p.getMember, p.getType)
+  }).isDefined
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext) = valueTypeDeser match {
+    case Some(d) => deserializeWithType(jp, ctxt, d)
+    case None => Option {
+      elementDeser.map(_.deserialize(jp, ctxt)).getOrElse {
+        ctxt.findContextualValueDeserializer(elementType, beanProperty.orNull).deserialize(jp, ctxt)
+      }
+    }.asInstanceOf[Option[AnyRef]]
+  }
+
+  override def deserializeWithType(jp: JsonParser, ctxt: DeserializationContext, typeDeserializer: TypeDeserializer) = Option {
+    elementDeser.map(_.deserializeWithType(jp, ctxt, typeDeserializer)).getOrElse {
+      ctxt.findContextualValueDeserializer(elementType, beanProperty.orNull).deserializeWithType(jp, ctxt, typeDeserializer)
+    }
+  }
 
   override def getNullValue = None
 }
@@ -33,9 +74,14 @@ private object OptionDeserializerResolver extends Deserializers.Base {
                                               config: DeserializationConfig,
                                               beanDesc: BeanDescription,
                                               elementTypeDeserializer: TypeDeserializer,
-                                              elementDeserializer: JsonDeserializer[_]) =
+                                              elementValueDeserializer: JsonDeserializer[_]) =
     if (!OPTION.isAssignableFrom(theType.getRawClass)) null
-    else new OptionDeserializer(theType.containedType(0), elementDeserializer)
+    else {
+      val elementType = theType.containedType(0)
+      val typeDeser = Option(elementTypeDeserializer).orElse(Option(elementType.getTypeHandler.asInstanceOf[TypeDeserializer]))
+      val valDeser: Option[JsonDeserializer[_]] = Option(elementValueDeserializer).orElse(Option(elementType.getValueHandler))
+      new OptionDeserializer(elementType, typeDeser, None, valDeser)
+    }
 }
 
 trait OptionDeserializerModule extends OptionTypeModifierModule {


### PR DESCRIPTION
I don't really have much idea what I'm doing, so the structure of
this code is mostly cargo-culted from OptionSerializerModule. Even
so, I've eschewed the use of a var for complex initialization, but I
don't understand Jackson well enough to name the intermediates
properly. I've also used for instead of chains of maps, to simplify
the code.

The gist is that OptionDeserializer is now a StdDeserializer, and has
a type deserializer to deserialize its element. This is needed for
deserializing polymorphic types using type information.

I've also added two regression tests for deserializing an Option of
an abstract type, for the two cases of Some and None. Like the code
itself, the two regression tests are based on the corresponding tests
in OptionSerializerTest.

Fixes: #147
