### PR TITLE
Spuriously `Succeeded` test outcomes?

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializationFixture.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializationFixture.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import org.scalatest.{Succeeded, Outcome, Matchers, fixture}
+import org.scalatest.{Outcome, Matchers, fixture}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -14,7 +14,6 @@ class DeserializationFixture extends fixture.FlatSpec with Matchers {
     val mapper = new ObjectMapper() with ScalaObjectMapper
     mapper.registerModule(DefaultScalaModule)
     test(mapper)
-    Succeeded
   }
 
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestPropertiesCollector.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestPropertiesCollector.scala
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.module.scala.deser.ScalaValueInstantiatorsModule
 import scala.volatile
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import scala.beans.{BeanProperty, BeanInfo}
-import org.scalatest.{Outcome, Succeeded, Matchers}
+import org.scalatest.{Outcome, Matchers}
 
 class Fields {
   @JsonProperty // make it "visible" for Jackson
@@ -51,7 +51,6 @@ class TestPropertiesCollector extends FlatSpec with Matchers {
     mapper.registerModule(new JacksonModule with ScalaClassIntrospectorModule with ScalaValueInstantiatorsModule)
 
     test(mapper)
-    Succeeded
   }
 
   behavior of "ScalaPropertiesCollector"

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.ser
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{Succeeded, Outcome, Matchers, fixture}
+import org.scalatest.{Outcome, Matchers, fixture}
 import com.fasterxml.jackson.databind.{PropertyNamingStrategy, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import java.io.ByteArrayOutputStream
@@ -25,7 +25,6 @@ class NamingStrategyTest extends fixture.FlatSpec with Matchers {
     mapper.registerModule(DefaultScalaModule)
     mapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
     test(mapper)
-    Succeeded
   }
 
   "DefaultScalaModule" should "correctly handle naming strategies" in { mapper =>


### PR DESCRIPTION
The explicit `Succeeded` test outcome returned in some base suites causes all dependent tests to pass - regardless of any failed assertions.

Is this intended or do I have a problem with my environment?
