### PR TITLE
Close #194, allow deserialization of tuples contianing abstract types

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerModule.scala
@@ -31,12 +31,14 @@ private class TupleDeserializer(javaType: JavaType,
 
     val paramDesers = paramTypes map (ctxt.findContextualValueDeserializer(_, property))
 
-    val typeDesers = Option(property).map { p =>
+    val typeDesers: Seq[TypeDeserializer] = {
       val factory = BeanDeserializerFactory.instance
-      paramTypes map { pt =>
-        factory.findPropertyTypeDeserializer(ctxt.getConfig, pt, property.getMember)
+      if (property != null) {
+        paramTypes map (factory.findPropertyTypeDeserializer(ctxt.getConfig, _, property.getMember))
+      } else {
+        paramTypes map (factory.findTypeDeserializer(config, _))
       }
-    } getOrElse Stream.fill(paramTypes.size)(null)
+    }
 
     new TupleDeserializer(javaType, config, paramDesers, typeDesers)
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
@@ -75,4 +75,11 @@ class TupleDeserializerTest extends DeserializerTest {
     val result = deserialize[TupleContainer](json)
     result should be (value)
   }
+
+  it should "deserialize using type information outside of field" in {
+    val value = (TupleValueLong(1), TupleValueString("foo"))
+    val json = mapper.writeValueAsString(value)
+    val result = deserialize[(TupleValueBase, TupleValueBase)](json)
+    result should be (value)
+  }
 }


### PR DESCRIPTION
See test case, which fails without this patch with this error:

```
[info] - should deserialize using type information outside of field *** FAILED ***
[info]   com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.fasterxml.jackson.module.scala.deser.TupleValueBase, problem: abstract types either need to be mapped to concrete types, have custom deserializer, or be instantiated with additional type information
[info]  at [Source: [{"type":"TupleValueLong","long":1},{"type":"TupleValueString","string":"foo"}]; line: 1, column: 2]
[info]   at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148)
[info]   at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:857)
[info]   at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserialize(AbstractDeserializer.java:139)
[info]   at com.fasterxml.jackson.module.scala.deser.TupleDeserializer$$anonfun$5.apply(TupleDeserializerModule.scala:63)
[info]   at com.fasterxml.jackson.module.scala.deser.TupleDeserializer$$anonfun$5.apply(TupleDeserializerModule.scala:60)
[info]   at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
[info]   at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
[info]   at scala.collection.Iterator$class.foreach(Iterator.scala:727)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
[info]   at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
[info]   ...
```