### PR TITLE
Upgrade to Jackson 2.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,12 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-scalacOptions in (Compile, compile) += "-Xfatal-warnings"
+// Temporarily disable warnings as fatal until migrate Option to new features.
+//scalacOptions in (Compile, compile) += "-Xfatal-warnings"
 
 // Ensure jvm 1.6 for java
 lazy val java6Home = new File(System.getenv("JAVA6_HOME"))
@@ -27,14 +28,14 @@ scalacOptions += "-target:jvm-1.6"
 
 libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "com.fasterxml.jackson.core" % "jackson-core" % "2.6.3",
-    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.3",
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.3",
-    "com.fasterxml.jackson.module" % "jackson-module-paranamer" % "2.6.3",
+    "com.fasterxml.jackson.core" % "jackson-core" % "2.7.2",
+    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.7.2",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.2",
+    "com.fasterxml.jackson.module" % "jackson-module-paranamer" % "2.7.2",
     // test dependencies
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.6.3" % "test",
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % "2.6.3" % "test",
-    "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % "2.6.3" % "test",
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.7.2" % "test",
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % "2.7.2" % "test",
+    "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % "2.7.2" % "test",
     "org.scalatest" %% "scalatest" % "2.2.1" % "test",
     "junit" % "junit" % "4.11" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.8

--- a/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
@@ -53,7 +53,7 @@ trait JacksonModule extends Module {
     val MinorVersion = version.getMinorVersion
     context.getMapperVersion match {
       case version@VersionExtractor(MajorVersion, minor) if minor < MinorVersion =>
-        throw new JsonMappingException("Jackson version is too old " + version)
+        throw new JsonMappingException(null, "Jackson version is too old " + version)
       case version@VersionExtractor(MajorVersion, minor) =>
         // Under semantic versioning, this check would not be needed; however Jackson
         // occasionally has functionally breaking changes across minor versions
@@ -61,10 +61,10 @@ trait JacksonModule extends Module {
         // depending on implementation details, so for now we'll just declare ourselves
         // as incompatible and move on.
         if (minor > MinorVersion) {
-          throw new JsonMappingException("Incompatible Jackson version: " + version)
+          throw new JsonMappingException(null, "Incompatible Jackson version: " + version)
         }
       case version =>
-        throw new JsonMappingException("Incompatible Jackson version: " + version)
+        throw new JsonMappingException(null, "Incompatible Jackson version: " + version)
     }
 
     initializers result() foreach (_ apply context)

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
@@ -41,7 +41,7 @@ private class OptionDeserializer(elementType: JavaType,
     p <- Option(property)
     intr <- Option(ctxt.getAnnotationIntrospector)
   } yield {
-    intr.findDeserializationContentType(p.getMember, p.getType)
+    intr.refineDeserializationType(ctxt.getConfig, p.getMember, p.getType)
   }).isDefined
 
   override def deserialize(jp: JsonParser, ctxt: DeserializationContext) = valueTypeDeser match {
@@ -73,7 +73,7 @@ private object OptionDeserializerResolver extends Deserializers.Base {
                                               elementValueDeserializer: JsonDeserializer[_]) =
     if (!OPTION.isAssignableFrom(theType.getRawClass)) null
     else {
-      val elementType = theType.containedType(0)
+      val elementType = theType.getContentType
       val typeDeser = Option(elementTypeDeserializer).orElse(Option(elementType.getTypeHandler.asInstanceOf[TypeDeserializer]))
       val valDeser: Option[JsonDeserializer[_]] = Option(elementValueDeserializer).orElse(Option(elementType.getValueHandler))
       new OptionDeserializer(elementType, typeDeser, None, valDeser)

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -27,16 +27,18 @@ private class BuilderWrapper[E](val builder: mutable.Builder[E, _ <: Iterable[E]
 }
 
 private object SeqDeserializer {
-  val COMPANIONS = new CompanionSorter[collection.Seq]()
+  val COMPANIONS = new CompanionSorter[collection.Iterable]()
     .add(IndexedSeq)
     .add(mutable.ArraySeq)
     .add(mutable.Buffer)
     .add(mutable.IndexedSeq)
     .add(mutable.LinearSeq)
     .add(mutable.ListBuffer)
+    .add(mutable.Iterable)
     .add(mutable.MutableList)
     .add(mutable.Queue)
     .add(mutable.ResizableArray)
+    .add(mutable.Seq)
     .add(Queue)
     .add(Stream)
     .toList

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -41,14 +41,14 @@ private class SortedMapDeserializer(
   with ContextualDeserializer {
   
   private val javaContainerType =
-    config.getTypeFactory.constructMapLikeType(classOf[MapBuilderWrapper[_,_]], collectionType.containedType(0), collectionType.containedType(1))
+    config.getTypeFactory.constructMapLikeType(classOf[MapBuilderWrapper[_,_]], collectionType.getKeyType, collectionType.getContentType)
 
   private val instantiator =
     new ValueInstantiator {
       def getValueTypeDesc = collectionType.getRawClass.getCanonicalName
       override def canCreateUsingDefault = true
       override def createUsingDefault(ctx: DeserializationContext) =
-        new SortedMapBuilderWrapper[AnyRef,AnyRef](SortedMapDeserializer.builderFor(collectionType.getRawClass, collectionType.containedType(0)))
+        new SortedMapBuilderWrapper[AnyRef,AnyRef](SortedMapDeserializer.builderFor(collectionType.getRawClass, collectionType.getKeyType))
     }
 
   private val containerDeserializer =
@@ -85,7 +85,6 @@ private object SortedMapDeserializerResolver extends Deserializers.Base {
                               elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] =
     if (!SORTED_MAP.isAssignableFrom(theType.getRawClass)) null
     else new SortedMapDeserializer(theType,config,keyDeserializer,elementDeserializer,elementTypeDeserializer)
-
 }
 
 /**

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerModule.scala
@@ -110,7 +110,7 @@ private object SortedSetDeserializerResolver extends Deserializers.Base {
     if (!SORTED_SET.isAssignableFrom(rawClass)) null
     else {
       val deser = elementDeserializer.asInstanceOf[JsonDeserializer[AnyRef]]
-      val instantiator = new SortedSetInstantiator(config, rawClass, collectionType.containedType(0))
+      val instantiator = new SortedSetInstantiator(config, rawClass, collectionType.getContentType)
       new SortedSetDeserializer(collectionType, deser, elementTypeDeserializer, instantiator)
     }
   }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -47,7 +47,7 @@ private class UnsortedMapDeserializer(
   with ContextualDeserializer {
 
   private val javaContainerType =
-    config.getTypeFactory.constructMapLikeType(classOf[MapBuilderWrapper[_,_]], collectionType.containedType(0), collectionType.containedType(1))
+    config.getTypeFactory.constructMapLikeType(classOf[MapBuilderWrapper[_,_]], collectionType.getKeyType, collectionType.getContentType)
 
   private val instantiator =
     new ValueInstantiator {
@@ -73,7 +73,7 @@ private class UnsortedMapDeserializer(
     }
 
   override def deserialize(jp: JsonParser, ctxt: DeserializationContext): GenMap[_,_] = {
-    containerDeserializer.deserialize(jp,ctxt) match {
+    containerDeserializer.deserialize(jp, ctxt) match {
       case wrapper: MapBuilderWrapper[_,_] => wrapper.builder.result()
     }
   }
@@ -96,7 +96,6 @@ private object UnsortedMapDeserializerResolver extends Deserializers.Base {
     else if (SORTED_MAP.isAssignableFrom(rawClass)) null
     else new UnsortedMapDeserializer(theType, config, keyDeserializer, elementDeserializer, elementTypeDeserializer)
   }
-
 }
 
 /**

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
@@ -4,6 +4,7 @@ import java.{util => ju}
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.`type`.{CollectionType, MapType}
 import com.fasterxml.jackson.databind.deser.{Deserializers, std}
 import com.fasterxml.jackson.databind.{BeanDescription, DeserializationConfig, DeserializationContext, DeserializationFeature, JavaType, JsonDeserializer}
 import com.fasterxml.jackson.module.scala.JacksonModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
@@ -24,7 +24,7 @@ object OrderingLocator {
     val ordering =
       found.getOrElse {
         if (matches(classOf[Option[_]])) {
-          val delegate = locate(javaType.containedType(0))
+          val delegate = locate(javaType.getContentType)
           Ordering.Option(delegate)
         }
         else if (matches(classOf[Comparable[_]]))

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -52,7 +52,7 @@ object ScalaAnnotationIntrospector extends NopAnnotationIntrospector
   private def isScala(a: Annotated): Boolean = {
     a match {
       case ac: AnnotatedClass => isMaybeScalaBeanType(ac.getAnnotated)
-      case am: AnnotatedMember => isMaybeScalaBeanType(am.getContextClass.getAnnotated)
+      case am: AnnotatedMember => isMaybeScalaBeanType(am.getDeclaringClass)
     }
   }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/CollectionLikeTypeModifier.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/CollectionLikeTypeModifier.scala
@@ -3,17 +3,17 @@ package com.fasterxml.jackson.module.scala.modifiers
 import java.lang.reflect.Type
 
 import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.databind.`type`.{TypeBindings, TypeFactory, TypeModifier}
+import com.fasterxml.jackson.databind.`type`.{CollectionLikeType, TypeBindings, TypeFactory, TypeModifier}
 
 private [modifiers] trait CollectionLikeTypeModifier extends TypeModifier with GenTypeModifier {
 
   def BASE: Class[_]
 
-  override def modifyType(originalType: JavaType, jdkType: Type, context: TypeBindings, typeFactory: TypeFactory) =
-    if (originalType.containedTypeCount() > 1) originalType else
-    classObjectFor(jdkType) find BASE.isAssignableFrom map { cls =>
-      val eltType = if (originalType.containedTypeCount() == 1) originalType.containedType(0) else UNKNOWN
-      typeFactory.constructCollectionLikeType(cls, eltType)
-    } getOrElse originalType
+  override def modifyType(originalType: JavaType, jdkType: Type, context: TypeBindings, typeFactory: TypeFactory) = {
+    if (classObjectFor(jdkType).exists(BASE.isAssignableFrom) && !originalType.isMapLikeType && originalType.containedTypeCount <= 1) {
+      val valType = originalType.containedTypeOrUnknown(0)
+      CollectionLikeType.upgradeFrom(originalType, valType)
+    } else originalType
+  }
 
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/MapTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/MapTypeModifierModule.scala
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.module.scala.modifiers
 
 import java.lang.reflect.Type
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.`type`.{TypeBindings, TypeFactory, TypeModifier};
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.`type`.{MapLikeType, TypeBindings, TypeFactory, TypeModifier}
 
 import com.fasterxml.jackson.module.scala.JacksonModule
 
@@ -11,12 +11,13 @@ private object MapTypeModifer extends TypeModifier with GenTypeModifier {
 
   val BASE = classOf[collection.Map[_,_]]
 
-  override def modifyType(originalType: JavaType, jdkType: Type, context: TypeBindings, typeFactory: TypeFactory) =
-    classObjectFor(jdkType) find (BASE.isAssignableFrom(_)) map { cls =>
-      val keyType = if (originalType.containedTypeCount() >= 1) originalType.containedType(0) else UNKNOWN
-      val valueType = if (originalType.containedTypeCount() >= 2) originalType.containedType(1) else UNKNOWN
-      typeFactory.constructMapLikeType(cls, keyType, valueType)
-    } getOrElse originalType
+  override def modifyType(originalType: JavaType, jdkType: Type, context: TypeBindings, typeFactory: TypeFactory) = {
+    if (classObjectFor(jdkType).exists(BASE.isAssignableFrom)) {
+      val keyType = originalType.containedTypeOrUnknown(0)
+      val valueType = originalType.containedTypeOrUnknown(1)
+      MapLikeType.upgradeFrom(originalType, keyType, valueType)
+    } else originalType
+  }
 
 }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializer.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializer.scala
@@ -52,7 +52,7 @@ private class EitherSerializer(elementType: Option[JavaType],
     }
     def hasContentTypeAnnotation(provider: SerializerProvider, property: BeanProperty) =
       Option(property).exists { p =>
-        Option(provider.getAnnotationIntrospector.findSerializationContentType(p.getMember, p.getType)).isDefined
+        Option(provider.getAnnotationIntrospector.refineSerializationType(provider.getConfig, p.getMember, p.getType)).isDefined
       }
 
     def tryContentSerializer(serializerProvider: SerializerProvider, property: BeanProperty, currentSer: Option[JsonSerializer[_]]) = {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -74,7 +74,7 @@ private object ScalaIteratorSerializerResolver extends Serializers.Base {
     
     val rawClass = collectionType.getRawClass
     if (!classOf[collection.Iterator[Any]].isAssignableFrom(rawClass)) null else
-    new UnresolvedIteratorSerializer(rawClass, collectionType.containedType(0), false, elementTypeSerializer, elementSerializer)
+    new UnresolvedIteratorSerializer(rawClass, collectionType.getContentType, false, elementTypeSerializer, elementSerializer)
   }
 }
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -105,7 +105,7 @@ class CaseClassDeserializerTest extends DeserializerTest {
 
   def propertyNamingStrategyMapper = new ObjectMapper() {
     registerModule(module)
-    setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+    setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
   }
 
   it should "honor the property naming strategy" in {
@@ -115,7 +115,7 @@ class CaseClassDeserializerTest extends DeserializerTest {
 
   it should "support serializing into instance var properties" in {
     val bean = new Bean("ctor")
-    val reader: ObjectReader = mapper.reader(bean.getClass)
+    val reader: ObjectReader = mapper.readerFor(bean.getClass)
     reader.withValueToUpdate(bean).readValue("""{"prop":"readValue"}""")
     bean.prop should be ("readValue")
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/PrimitiveContainerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/PrimitiveContainerTest.scala
@@ -12,8 +12,8 @@ object PrimitiveContainerTest
   case class OptionLong(value: Option[Long])
   case class AnnotatedOptionLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) value: Option[Long])
 
-  case class AnnotatedHashKeyLong(@JsonDeserialize(keyAs = classOf[java.lang.Long]) value: Map[Long,String])
-  case class AnnotatedHashValueLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) value: Map[String,Long])
+  case class AnnotatedHashKeyLong(@JsonDeserialize(keyAs = classOf[java.lang.Long]) value: Map[Long, String])
+  case class AnnotatedHashValueLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) value: Map[String, Long])
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -45,7 +45,7 @@ class PrimitiveContainerTest extends DeserializationFixture
     thrown.getMessage should startWith ("Numeric value (9223372036854775807) out of range")
   }
 
-  it should "support map keys" ignore { f =>
+  it should "support map keys" in { f =>
     val value = f.readValue[AnnotatedHashKeyLong]("""{"value":{"1":"one"}}""")
     value.value should contain key 1L
     value.value(1L) shouldBe "one"

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerTest.scala
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.scala.deser
 import com.fasterxml.jackson.module.scala.{JacksonModule, DefaultScalaModule}
 import com.fasterxml.jackson.databind.{ObjectMapper, DeserializationConfig, JavaType, AbstractTypeResolver}
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.fasterxml.jackson.databind.`type`.MapLikeType
+import com.fasterxml.jackson.databind.`type`.{TypeFactory, MapLikeType}
 
 class UntypedObjectDeserializerTest extends DeserializerTest {
   def module = DefaultScalaModule
@@ -29,7 +29,7 @@ class UntypedObjectDeserializerTest extends DeserializerTest {
         val result = Some(javaType) collect {
           case mapLikeType: MapLikeType =>
             if (javaType.getRawClass.equals(classOf[collection.Map[_,_]])) {
-              javaType.narrowBy(classOf[collection.immutable.TreeMap[_,_]])
+              TypeFactory.defaultInstance().constructSpecializedType(javaType, classOf[collection.immutable.TreeMap[_,_]])
             } else null
         }
         result.orNull

--- a/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
@@ -129,12 +129,12 @@ class ScalaObjectMapperTest extends FlatSpec with Matchers {
   }
 
   it should "produce reader with type" in {
-    val result = mapper.reader[GenericTestClass[Int]].readValue(genericJson).asInstanceOf[GenericTestClass[Int]]
+    val result = mapper.readerFor[GenericTestClass[Int]].readValue(genericJson).asInstanceOf[GenericTestClass[Int]]
     result should equal(genericInt)
   }
 
   it should "produce reader with view" in {
-    val reader = mapper.readerWithView[PublicView].withType(classOf[Target])
+    val reader = mapper.readerWithView[PublicView].forType(classOf[Target])
     val result = reader.readValue("""{"foo":"foo","bar":42}""").asInstanceOf[Target]
     result should equal(Target.apply("foo", 0))
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospectorTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospectorTest.scala
@@ -1,13 +1,15 @@
 package com.fasterxml.jackson.module.scala.introspect
 
+import java.lang.reflect.Member
+
+import com.fasterxml.jackson.module.scala.BaseSpec
 import com.fasterxml.jackson.module.scala.introspect.BeanIntrospectorTest.DecodedNameMatcher
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{Inside, OptionValues, LoneElement, FlatSpec}
-import org.scalatest.matchers.{HavePropertyMatcher, HavePropertyMatchResult, ShouldMatchers}
-import reflect.NameTransformer
-import com.fasterxml.jackson.module.scala.BaseSpec
-import java.lang.reflect.Member
+import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
+import org.scalatest.{Inside, LoneElement, OptionValues}
+
+import scala.reflect.NameTransformer
 
 object BeanIntrospectorTest {
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -134,7 +134,7 @@ class CaseClassSerializerTest extends SerializerTest {
 
   def propertyNamingStrategyMapper = new ObjectMapper() {
     registerModule(module)
-    setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+    setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
   }
 
   it should "honor the property naming strategy" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -73,10 +73,8 @@ class IterableSerializerTest extends SerializerTest {
     serialize(mutable.LinkedHashSet(1,2,3)) should matchUnorderedSet
   }
 
-  it should "not serialize a Map[Int]" ignore {
-    intercept[JsonMappingException] {
-      serialize(Map(1->2,3->4))
-    }
+  it should "serialize a Map[Int]" in {
+    serialize(Map(1->2,3->4)) should matchUnorderedMap
   }
 
   it should "honor the JsonInclude(NON_EMPTY) annotation" in {
@@ -94,5 +92,10 @@ class IterableSerializerTest extends SerializerTest {
     be ("[2,3,1]") or
     be ("[3,1,2]") or
     be ("[3,2,1]")
+  }
+
+  val matchUnorderedMap = {
+    be ("{\"1\":2,\"3\":4}") or
+    be ("{\"3\":4,\"1\":2}")
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
@@ -25,7 +25,7 @@ class NamingStrategyTest extends fixture.FlatSpec with Matchers {
   protected def withFixture(test: OneArgTest): Outcome = {
     val mapper = new ObjectMapper()
     mapper.registerModule(DefaultScalaModule)
-    mapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+    mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
     test(mapper)
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.6.4-SNAPSHOT"
+version in ThisBuild := "2.7.2-SNAPSHOT"


### PR DESCRIPTION
Upgrades to Jackson 2.7 branch. All current tests pass.

Depends on this databind pull-request:
https://github.com/FasterXML/jackson-databind/pull/1129