### PR TITLE
Cross-build for Scala 2.12.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,21 @@ cache:
     - $HOME/.sbt
 
 language: scala
-jdk:
-   - oraclejdk8
-   - openjdk6
+matrix:
+  include:
+    # Test Scala 2.10 and 2.11 with both JDK 6 and 8
+    - scala: 2.10.6
+      jdk: openjdk6
+    - scala: 2.11.7
+      jdk: openjdk6
+    - scala: 2.10.6
+      jdk: oraclejdk8
+    - scala: 2.11.7
+      jdk: oraclejdk8
+    # Scala 2.12+ only supports JDK 8+
+    - scala: 2.12.0-M4
+      jdk: oraclejdk8
 
-scala:
-   - 2.10.6
-   - 2.11.7
 sbt_args: "'set resolvers += \"Sonatype OSS Snapshots\" at \"https://oss.sonatype.org/content/repositories/snapshots\"'"
 
 before_script:
@@ -21,7 +29,7 @@ before_script:
 
 after_success:
   - >
-      test "${TRAVIS_PULL_REQUEST}" = 'false' && test "${TRAVIS_JDK_VERSION}" = 'openjdk6' &&
+      test "${TRAVIS_PULL_REQUEST}" = 'false' && test "${TRAVIS_JDK_VERSION}" = 'openjdk6' -o "${TRAVIS_SCALA_VERSION}" = '2.12.0-M4' &&
       sbt 'set resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"'
       'set credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", System.getenv("SONATYPE_USER"), System.getenv("SONATYPE_PASS"))'
       ++${TRAVIS_SCALA_VERSION}

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
@@ -25,8 +25,15 @@ javacOptions ++= Seq(
   "-bootclasspath", Array((java6Home / "jre" / "lib" / "rt.jar").toString, (java6Home / ".." / "Classes"/ "classes.jar").toString).mkString(File.pathSeparator)
 )
 
-// Try to future-proof scala jvm targets, in case some future scala version makes 1.7 a default
-scalacOptions += "-target:jvm-1.6"
+scalacOptions ++= (
+  if (scalaVersion.value.startsWith("2.12")) {
+    // -target is deprecated as of Scala 2.12, which uses JVM 1.8 bytecode
+    Seq.empty
+  } else {
+    // Explicitly target 1.6 for scala < 2.12
+    Seq("-target:jvm-1.6")
+  }
+)
 
 libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -38,7 +45,7 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.7.2" % "test",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % "2.7.2" % "test",
     "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % "2.7.2" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
     "junit" % "junit" % "4.11" % "test"
 )
 


### PR DESCRIPTION
This patch adds cross-build support for Scala 2.12.0-M4. This required small changes to the Travis and SBT configurations to account for the fact that Scala 2.12 requires JDK 8+.

Fixes #245.