### PR TITLE
Test custom scala module creation.

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaNumberDeserializersModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaNumberDeserializersModule.scala
@@ -57,6 +57,6 @@ private object NumberDeserializers extends Deserializers.Base
     }
 }
 
-private [scala] trait ScalaNumberDeserializersModule extends JacksonModule {
+trait ScalaNumberDeserializersModule extends JacksonModule {
   this += NumberDeserializers
 }

--- a/src/test/scala/com/fasterxml/jackson/module/external/CustomScalaModuleTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/external/CustomScalaModuleTest.scala
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.module.external
+
+import com.fasterxml.jackson.module.scala._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class CustomScalaModuleTest extends BaseSpec {
+
+    "A custom scala module" should "be buildable outside of the module package" in {
+        """
+          |
+          |import com.fasterxml.jackson.module.scala._
+          |import com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
+          |import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
+          |
+          |class CustomScalaModule
+          |  extends JacksonModule
+          |     with IteratorModule
+          |     with EnumerationModule
+          |     with OptionModule
+          |     with SeqModule
+          |     with IterableModule
+          |     with TupleModule
+          |     with MapModule
+          |     with SetModule
+          |     with ScalaNumberDeserializersModule
+          |     with ScalaAnnotationIntrospectorModule
+          |     with UntypedObjectDeserializerModule
+          |     with EitherModule
+          |
+        """.stripMargin should compile
+    }
+
+}


### PR DESCRIPTION
It's not currently possible to pick and choose bits of the module that you want to include because of a package private class.
This means it requires more code to build a custom module that modifiers / excludes particular behaviours.

It would also help to increase the visibility on the Deserializer classes themselves, would this be acceptable?
