### PR TITLE
Cross-build for Scala 2.12.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - scala: 2.11.8
       jdk: oraclejdk8
     # Scala 2.12+ only supports JDK 8+
-    - scala: 2.12.0-M4
+    - scala: 2.12.0-M5
       jdk: oraclejdk8
 
 sbt_args: "'set resolvers += \"Sonatype OSS Snapshots\" at \"https://oss.sonatype.org/content/repositories/snapshots\"'"
@@ -27,7 +27,7 @@ before_script:
 
 after_success:
   - >
-      test "${TRAVIS_PULL_REQUEST}" = 'false' && test "${TRAVIS_JDK_VERSION}" = 'oraclejdk7' -o "${TRAVIS_SCALA_VERSION}" = '2.12.0-M4' &&
+      test "${TRAVIS_PULL_REQUEST}" = 'false' && test "${TRAVIS_JDK_VERSION}" = 'oraclejdk7' -o "${TRAVIS_SCALA_VERSION}" = '2.12.0-M5' &&
       sbt 'set resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"'
       'set credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", System.getenv("SONATYPE_USER"), System.getenv("SONATYPE_PASS"))'
       ++${TRAVIS_SCALA_VERSION}

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M5")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
@@ -41,6 +41,14 @@ val jacksonVersion = "2.8.0"
 
 val jacksonSnapshotVersion = "2.8.1-SNAPSHOT"
 
+//scala 2.12.0-M5+ requires scalatest 3+
+val scalaTestVersion = Def.setting{
+  scalaVersion.value match {
+    case "2.12.0-M5" => "3.0.0-RC4"
+    case _ => "2.2.6"
+  }
+}
+
 libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -51,7 +59,7 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % "test",
     "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "org.scalatest" %% "scalatest" % scalaTestVersion.value % "test",
     "junit" % "junit" % "4.11" % "test"
 )
 

--- a/src/test/scala/UnpackagedTest.scala
+++ b/src/test/scala/UnpackagedTest.scala
@@ -3,7 +3,7 @@ import com.fasterxml.jackson.module.scala.ser.SerializerTest
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 case class UnpackagedCaseClass(intValue: Int, stringValue: String)
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/DefaultScalaModuleTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/DefaultScalaModuleTest.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/UnwrappedTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/UnwrappedTest.scala
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.scala
 import com.fasterxml.jackson.annotation.{JsonUnwrapped, JsonProperty, JsonIgnore}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import com.fasterxml.jackson.databind.ObjectMapper
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/InteropTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/InteropTest.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.scalatest.{Matchers, FlatSpec}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/IterableDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/IterableDeserializerTest.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 class IterableDeserializerTest extends DeserializationFixture {
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MiscTypesTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MiscTypesTest.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import java.util.UUID

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.annotation.{JsonTypeName, JsonSubTypes, JsonTypeInfo}
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.fasterxml.jackson.module.scala.DefaultScalaModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithJodaTimeDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithJodaTimeDeserializerTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.deser
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.datatype.joda.JodaModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.deser
 
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 import collection.LinearSeq
 import collection.mutable

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.scala.deser
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import scala.collection.SortedMap
 import scala.collection.immutable.TreeMap
 import java.util.UUID

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.deser
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import scala.collection.mutable
 import scala.collection.SortedSet
 import scala.collection.immutable.TreeSet

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/TestInnerClass.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/TestInnerClass.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.scala.deser
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
 import com.fasterxml.jackson.core.`type`.TypeReference

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.module.scala.deser
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import scala.collection.{immutable, mutable}
 
 @RunWith(classOf[JUnitRunner])

--- a/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.scala.experimental
 
 import org.scalatest.{Matchers, FlatSpec}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import com.fasterxml.jackson.module.scala.DefaultScalaModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestSyntheticBridgeMethods.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestSyntheticBridgeMethods.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.introspect
 
-import org.scalatest.{LoneElement, Inside, FlatSpec, ShouldMatchers}
+import org.scalatest.{LoneElement, Inside, FlatSpec, Matchers}
 import com.fasterxml.jackson.module.scala.BaseSpec
 
 object TestSyntheticBridgeMethods {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerTest.scala
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.scala.ser
 
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.fasterxml.jackson.module.scala.JacksonModule


### PR DESCRIPTION
* Upgrade 2.12 version to latest milestone, M5
* Upgrade Scalatest version to work with latest Scala version