### PR TITLE
be compatible with Scala 2.12 community build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,11 @@ scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 scalacOptions in (Compile, compile) += "-Xfatal-warnings"
 
 // Ensure jvm 1.7 for java
-lazy val java7Home = Option(System.getenv("JAVA7_HOME")).map(new File(_)).getOrElse {
-  sys.error("Please set JAVA7_HOME environment variable")
-}
+lazy val java7Home =
+  Option(System.getenv("JAVA7_HOME"))
+    .orElse(Option(System.getProperty("JAVA7_HOME")))
+    .map(new File(_))
+    .getOrElse { sys.error("Please set JAVA7_HOME environment variable or system property") }
 
 javacOptions ++= Seq(
   "-source", "1.7",


### PR DESCRIPTION
I would like to add jackson-module-scala to the Scala 2.12 community build.
for its own sake, but also because it's a dependency of ScalaMeter.

dbuild is good at setting Java system properties but not so good at
setting environment variables, as far as I can determine. mind including
this change...?
