### PR TITLE
Upgrade Scala 2.12 version to 2.12.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - scala: 2.11.8
       jdk: oraclejdk8
     # Scala 2.12+ only supports JDK 8+
-    - scala: 2.12.0-M5
+    - scala: 2.12.0
       jdk: oraclejdk8
 
 sbt_args: "'set resolvers += \"Sonatype OSS Snapshots\" at \"https://oss.sonatype.org/content/repositories/snapshots\"'"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-RC1")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 


### PR DESCRIPTION
The absence of `jackson-module-scala` is a blocker for us. Would you please publish libs for Scala 2.12.0 when you have time?