### PR TITLE
Fix bean accessors being used for field names

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
@@ -194,7 +194,8 @@ object BeanIntrospector {
       if findField(cls, name).isEmpty
       if !name.contains('$')
       if !fields.exists(_.name == name)
-      setter = findSetter(cls, name) if setter.isDefined || getter.getAnnotation(classOf[JsonProperty]) != null
+      getterProperty = getter.getAnnotation(classOf[JsonProperty])
+      setter = findSetter(cls, name) if setter.isDefined || (getterProperty != null && getterProperty.value != JsonProperty.USE_DEFAULT_NAME)
       beanGetter = findBeanGetter(cls, name)
       beanSetter = findBeanSetter(cls, name)
     } yield PropertyDescriptor(name, None, None, Some(getter), setter, beanGetter, beanSetter)


### PR DESCRIPTION
When using `@JsonProperty` on a bean property (i.e. a field with
accessor methods), if you do not specify an explicit name for the
property, the `ScalaAnnotationIntrospector` was incorrectly generating
properties for the accessor methods.

In the following example:

```
class Bean {
  private var value: Int = 0

  @JsonProperty
  def getValue: Int = value

  @JsonProperty
  def setValue(value: Int): Unit = { this.value = value }
}
```

A mapper configured with the `ScalaAnnotationIntrospector` would
serialize this to:

```
{"value":0,"getValue":0}
```

This most notably impacts interop with Java-defined classes, as they
often follow the pattern of Java Beans, where the accessor methods are
annotated with `@JsonProperty`.

Credit for the fix goes to [@clintmiller1](https://github.com/FasterXML/jackson-module-scala/issues/224#issuecomment-249909564).

I've included a test that verifies the problem, and the solution.