### PR TITLE
Fix map deserialization of nullary values.

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
@@ -1,19 +1,19 @@
 package com.fasterxml.jackson.module.scala
 
 import com.fasterxml.jackson.core.Version
-
 import com.fasterxml.jackson.databind.{JsonMappingException, Module}
 import com.fasterxml.jackson.databind.Module.SetupContext
 import com.fasterxml.jackson.databind.deser.Deserializers
-import com.fasterxml.jackson.databind.ser.{Serializers, BeanSerializerModifier}
+import com.fasterxml.jackson.databind.ser.{BeanSerializerModifier, Serializers}
 import com.fasterxml.jackson.databind.`type`.TypeModifier
-
 import java.util.Properties
+
 import collection.JavaConverters._
 import collection.mutable
 
+import com.fasterxml.jackson.core.util.VersionUtil
+
 object JacksonModule {
-  private val VersionRegex = """(\d+)\.(\d+)(?:\.(\d+)(?:\.([\d\w]+)(?:[-.]rc(?:\d+)*)?(?:\-(.*))?)?)?""".r
   private val cls = classOf[JacksonModule]
   private val buildPropsFilename = cls.getPackage.getName.replace('.','/') + "/build.properties"
   lazy val buildProps: mutable.Map[String, String] = {
@@ -26,13 +26,8 @@ object JacksonModule {
   lazy val version: Version = {
     val groupId = buildProps("groupId")
     val artifactId = buildProps("artifactId")
-    buildProps("version") match {
-      case VersionRegex(major,minor,patchOpt,preOrRcOpt, snapOpt) => {
-        val patch = Option(patchOpt) map (_.toInt) getOrElse 0
-        new Version(major.toInt,minor.toInt,patch,snapOpt,groupId,artifactId)
-      }
-      case _ => Version.unknownVersion()
-    }
+    val version = buildProps("version")
+    VersionUtil.parseVersion(version, groupId, artifactId)
   }
 }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -1,14 +1,11 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import java.util.AbstractMap
-import java.util.Map.Entry
-
-import scala.collection.{mutable, SortedMap}
+import scala.collection.{SortedMap, mutable}
 import scala.collection.immutable.TreeMap
 
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.deser.std.{MapDeserializer, ContainerDeserializerBase}
+import com.fasterxml.jackson.databind.deser.std.{ContainerDeserializerBase, MapDeserializer, StdValueInstantiator}
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 import com.fasterxml.jackson.databind.`type`.MapLikeType
 import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
@@ -16,56 +13,42 @@ import deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
 import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
 import scala.language.existentials
 
-private class SortedMapBuilderWrapper[K,V](val builder: mutable.Builder[(K,V), SortedMap[K,V]]) extends AbstractMap[K,V] {
-  override def put(k: K, v: V) = { builder += ((k,v)); v }
+private class SortedMapBuilderWrapper[K,V](val builder: mutable.Builder[(K,V), SortedMap[K,V]]) extends java.util.AbstractMap[K,V] {
+  override def put(k: K, v: V): V = { builder += ((k,v)); v }
 
   // Isn't used by the deserializer
-  def entrySet(): java.util.Set[Entry[K, V]] = throw new UnsupportedOperationException
+  def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = throw new UnsupportedOperationException
 }
 
 private object SortedMapDeserializer {
-  def orderingFor = OrderingLocator.locate _
+  private def orderingFor = OrderingLocator.locate _
 
   def builderFor(cls: Class[_], keyCls: JavaType): mutable.Builder[(AnyRef,AnyRef), SortedMap[AnyRef,AnyRef]] =
     if (classOf[TreeMap[_,_]].isAssignableFrom(cls)) TreeMap.newBuilder[AnyRef,AnyRef](orderingFor(keyCls)) else
     SortedMap.newBuilder[AnyRef,AnyRef](orderingFor(keyCls))
 }
 
-private class SortedMapDeserializer(
-    collectionType: MapLikeType,
-    config: DeserializationConfig,
-    keyDeser: KeyDeserializer,
-    valueDeser: JsonDeserializer[_],
-    valueTypeDeser: TypeDeserializer)
-  extends ContainerDeserializerBase[SortedMap[_,_]](collectionType)
-  with ContextualDeserializer {
-  
-  private val javaContainerType =
-    config.getTypeFactory.constructMapLikeType(classOf[MapBuilderWrapper[_,_]], collectionType.getKeyType, collectionType.getContentType)
+private class SortedMapInstantiator(config: DeserializationConfig, mapType: MapLikeType) extends StdValueInstantiator(config, mapType) {
+  override def canCreateUsingDefault = true
+  override def createUsingDefault(ctxt: DeserializationContext) =
+    new SortedMapBuilderWrapper[AnyRef,AnyRef](SortedMapDeserializer.builderFor(mapType.getRawClass, mapType.getKeyType))
+}
 
-  private val instantiator =
-    new ValueInstantiator {
-      override def getValueTypeDesc = collectionType.getRawClass.getCanonicalName
-      override def canCreateUsingDefault = true
-      override def createUsingDefault(ctx: DeserializationContext) =
-        new SortedMapBuilderWrapper[AnyRef,AnyRef](SortedMapDeserializer.builderFor(collectionType.getRawClass, collectionType.getKeyType))
-    }
+private class SortedMapDeserializer(mapType: MapLikeType, containerDeserializer: MapDeserializer)
+  extends ContainerDeserializerBase[SortedMap[_,_]](mapType) with ContextualDeserializer {
 
-  private val containerDeserializer =
-    new MapDeserializer(javaContainerType,instantiator,keyDeser,valueDeser.asInstanceOf[JsonDeserializer[AnyRef]],valueTypeDeser)
+  def this(mapType: MapLikeType, valueInstantiator: ValueInstantiator, keyDeser: KeyDeserializer, valueDeser: JsonDeserializer[_], valueTypeDeser: TypeDeserializer) = {
+    this(mapType, new MapDeserializer(mapType, valueInstantiator, keyDeser, valueDeser.asInstanceOf[JsonDeserializer[AnyRef]], valueTypeDeser))
+  }
 
-  override def getContentType = containerDeserializer.getContentType
+  override def getContentType: JavaType = containerDeserializer.getContentType
+  override def getContentDeserializer: JsonDeserializer[AnyRef] = containerDeserializer.getContentDeserializer
 
-  override def getContentDeserializer = containerDeserializer.getContentDeserializer
+  override def createContextual(ctxt: DeserializationContext, property: BeanProperty): JsonDeserializer[_] = {
+    val newDelegate = containerDeserializer.createContextual(ctxt, property).asInstanceOf[MapDeserializer]
+    new SortedMapDeserializer(mapType, newDelegate)
+  }
 
-  override def createContextual(ctxt: DeserializationContext, property: BeanProperty) =
-    if (keyDeser != null && valueDeser != null) this
-    else {
-      val newKeyDeser = Option(keyDeser).getOrElse(ctxt.findKeyDeserializer(collectionType.getKeyType, property))
-      val newValDeser = Option(valueDeser).getOrElse(ctxt.findContextualValueDeserializer(collectionType.getContentType, property))
-      new SortedMapDeserializer(collectionType, config, newKeyDeser, newValDeser, valueTypeDeser)
-    }
-  
   override def deserialize(jp: JsonParser, ctxt: DeserializationContext): SortedMap[_,_] = {
     containerDeserializer.deserialize(jp,ctxt) match {
       case wrapper: SortedMapBuilderWrapper[_,_] => wrapper.builder.result()
@@ -74,7 +57,7 @@ private class SortedMapDeserializer(
 }
 
 private object SortedMapDeserializerResolver extends Deserializers.Base {
-  
+
   private val SORTED_MAP = classOf[collection.SortedMap[_,_]]
 
   override def findMapLikeDeserializer(theType: MapLikeType,
@@ -84,7 +67,10 @@ private object SortedMapDeserializerResolver extends Deserializers.Base {
                               elementTypeDeserializer: TypeDeserializer,
                               elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] =
     if (!SORTED_MAP.isAssignableFrom(theType.getRawClass)) null
-    else new SortedMapDeserializer(theType,config,keyDeserializer,elementDeserializer,elementTypeDeserializer)
+    else {
+      val instantiator = new SortedMapInstantiator(config, theType)
+      new SortedMapDeserializer(theType, instantiator, keyDeserializer, elementDeserializer, elementTypeDeserializer)
+    }
 }
 
 /**

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
@@ -2,12 +2,13 @@ package com.fasterxml.jackson.module.scala.deser
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
 import scala.collection.SortedMap
 import scala.collection.immutable.TreeMap
 import java.util.UUID
+
 import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 
 /**
  * @author Christopher Currie <ccurrie@impresys.com>
@@ -43,10 +44,29 @@ class SortedMapDeserializerTest extends DeserializerTest {
     result.keys.head shouldBe UUID.fromString("e79bf81e-3902-4801-831f-d161be435787")
   }
 
-  val mapJson =  """{ "one": "1", "two": "2" }"""
-  val mapScala = SortedMap("one"->"1","two"->"2")
-  val variantMapJson = """{ "one": "1", "two": 2 }"""
-  val variantMapScala = SortedMap[String,Any]("one"->"1","two"->2)
-  val numericMapJson = """{ "1": "one", "2": "two" }"""
-  val numericMapScala = SortedMap[Integer,String](Integer.valueOf(1)->"one",Integer.valueOf(2)->"two")
+  it should "properly deserialize nullary values" in {
+    val result = deserialize[SortedMap[String, JsonNode]](nullValueMapJson)
+    result should equal (nullValueMapScala)
+  }
+
+  private val mapJson =  """{ "one": "1", "two": "2" }"""
+  private val mapScala = SortedMap("one"->"1","two"->"2")
+  private val variantMapJson = """{ "one": "1", "two": 2 }"""
+  private val variantMapScala = SortedMap[String,Any]("one"->"1","two"->2)
+  private val numericMapJson = """{ "1": "one", "2": "two" }"""
+  private val numericMapScala = SortedMap[Integer,String](Integer.valueOf(1)->"one",Integer.valueOf(2)->"two")
+  private val nullValueMapJson =
+    """
+      |{
+      | "foo": "bar",
+      | "nullValue": null,
+      | "intValue": 1234
+      |}
+    """.stripMargin
+  private val nullValueMapScala = SortedMap[String, JsonNode](
+    "foo" -> JsonNodeFactory.instance.textNode("bar"),
+    "nullValue" -> JsonNodeFactory.instance.nullNode(),
+    "intValue" -> JsonNodeFactory.instance.numberNode(1234)
+  )
+
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
@@ -5,9 +5,13 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import scala.collection.immutable.HashMap
-import scala.collection.mutable
+import scala.collection.{SortedMap, mutable}
+
 import com.fasterxml.jackson.core.`type`.TypeReference
 import java.util.UUID
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 
 /**
  * @author Christopher Currie <ccurrie@impresys.com>
@@ -52,8 +56,27 @@ class UnsortedMapDeserializerTest extends DeserializerTest {
     result.keys.head shouldBe (UUID.fromString("e79bf81e-3902-4801-831f-d161be435787"))
   }
 
-  val mapJson =  """{ "one": "1", "two": "2" }"""
-  val mapScala = Map("one"->"1","two"->"2")
-  val variantMapJson = """{ "one": "1", "two": 2 }"""
-  val variantMapScala = Map[String,Any]("one"->"1","two"->2)
+  it should "properly deserialize nullary values" in {
+    val result = deserialize[Map[String, JsonNode]](nullValueMapJson)
+    result should equal (nullValueMapScala)
+  }
+
+  private val mapJson =  """{ "one": "1", "two": "2" }"""
+  private val mapScala = Map("one"->"1","two"->"2")
+  private val variantMapJson = """{ "one": "1", "two": 2 }"""
+  private val variantMapScala = Map[String,Any]("one"->"1","two"->2)
+  private val nullValueMapJson =
+    """
+      |{
+      | "foo": "bar",
+      | "nullValue": null,
+      | "intValue": 1234
+      |}
+    """.stripMargin
+  private val nullValueMapScala = Map[String, JsonNode](
+    "foo" -> JsonNodeFactory.instance.textNode("bar"),
+    "nullValue" -> JsonNodeFactory.instance.nullNode(),
+    "intValue" -> JsonNodeFactory.instance.numberNode(1234)
+  )
+
 }


### PR DESCRIPTION
Make Map and SortedMap deserializers properly create contextual instances, and thus be able to handle nullary value types using the new Jackson 2.9 null value handling.