### PR TITLE
Scala 2.10.6 --> Scala 2.10.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ language: scala
 matrix:
   include:
     # Test Scala 2.10 and 2.11 with both JDK 6 and 8
-    - scala: 2.10.6
+    - scala: 2.10.7
       jdk: openjdk7
     - scala: 2.11.8
       jdk: openjdk7
-    - scala: 2.10.6
+    - scala: 2.10.7
       jdk: oraclejdk8
     - scala: 2.11.8
       jdk: oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.6")
+crossScalaVersions := Seq("2.10.7", "2.11.11", "2.12.6")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 


### PR DESCRIPTION
note:  Scala 2.10.7 adds JDK9 compatibility