### PR TITLE
fix scala 2.13 compile warnings 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.6")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.6", "2.13.0-M4")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
@@ -32,7 +32,7 @@ javacOptions ++= Seq(
 )
 
 scalacOptions ++= (
-  if (scalaVersion.value.startsWith("2.12")) {
+  if (scalaVersion.value.startsWith("2.12") || scalaVersion.value.startsWith("2.13")) {
     // -target is deprecated as of Scala 2.12, which uses JVM 1.8 bytecode
     Seq.empty
   } else {
@@ -53,8 +53,8 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % "test",
     "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion % "test",
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "junit" % "junit" % "4.11" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.6-SNAP1" % "test",
+    "junit" % "junit" % "4.12" % "test"
 )
 
 // build.properties

--- a/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
@@ -43,7 +43,7 @@ trait JacksonModule extends Module {
 
   def version = JacksonModule.version
 
-  def setupModule(context: SetupContext) {
+  def setupModule(context: SetupContext): Unit = {
     val MajorVersion = version.getMajorVersion
     val MinorVersion = version.getMinorVersion
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
@@ -20,7 +20,7 @@ private class UntypedObjectDeserializer extends std.UntypedObjectDeserializer(nu
   private var _mapDeser: JsonDeserializer[AnyRef] = _
   private var _listDeser: JsonDeserializer[AnyRef] = _
 
-  override def resolve(ctxt: DeserializationContext) {
+  override def resolve(ctxt: DeserializationContext): Unit = {
     super.resolve(ctxt)
     val anyRef = ctxt.constructType(classOf[AnyRef])
     val string = ctxt.constructType(classOf[String])

--- a/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
@@ -326,7 +326,7 @@ trait ScalaObjectMapper {
    *
    * @since 2.1
    */
-  def acceptJsonFormatVisitor[T: Manifest](visitor: JsonFormatVisitorWrapper) {
+  def acceptJsonFormatVisitor[T: Manifest](visitor: JsonFormatVisitorWrapper): Unit = {
     acceptJsonFormatVisitor(manifest[T].runtimeClass, visitor)
   }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerModule.scala
@@ -36,7 +36,7 @@ private class EnumerationSerializer extends JsonSerializer[scala.Enumeration#Val
 }
 
 private class AnnotatedEnumerationSerializer extends JsonSerializer[scala.Enumeration#Value] with ContextualEnumerationSerializer {
-  override def serialize(value: scala.Enumeration#Value, jgen: JsonGenerator, provider: SerializerProvider) {
+  override def serialize(value: scala.Enumeration#Value, jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     jgen.writeString(value.toString)
   }
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerModule.scala
@@ -24,7 +24,7 @@ private trait IterableSerializer
   override def hasSingleElement(value: collection.Iterable[Any]): Boolean =
     value.hasDefiniteSize && value.size == 1
 
-  override def serializeContents(value: collection.Iterable[Any], gen: JsonGenerator, provider: SerializerProvider) {
+  override def serializeContents(value: collection.Iterable[Any], gen: JsonGenerator, provider: SerializerProvider): Unit = {
     collectionSerializer.serializeContents(value.asJavaCollection, gen, provider)
   }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -24,7 +24,7 @@ private trait IteratorSerializer
   override def hasSingleElement(p1: collection.Iterator[Any]) =
     p1.hasDefiniteSize && p1.size == 1
 
-  def serializeContents(value: collection.Iterator[Any], jgen: JsonGenerator, provider: SerializerProvider) {
+  def serializeContents(value: collection.Iterator[Any], jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     iteratorSerializer.serializeContents(value.asJava, jgen, provider)
   }
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerModule.scala
@@ -8,8 +8,7 @@ import com.fasterxml.jackson.module.scala.JacksonModule;
 
 private class TupleSerializer extends JsonSerializer[Product] {
   
-  def serialize(value: Product, jgen: JsonGenerator, provider: SerializerProvider)
-  {
+  def serialize(value: Product, jgen: JsonGenerator, provider: SerializerProvider): Unit = {
     jgen.writeStartArray()
     value.productIterator.foreach(jgen.writeObject _)
     jgen.writeEndArray()


### PR DESCRIPTION
And use scalatest version that supports scala 2.13.0-M4

Does not address the compile errors with scala 2.13.0-M4 which will need bigger changes.

This pull request is just a partial move towards scala 2.13.0-M4 support

relates to https://github.com/FasterXML/jackson-module-scala/issues/379