### PR TITLE
Fix deserialization of un-annotated Option[Trait] fields

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
@@ -68,7 +68,8 @@ private class OptionDeserializer(fullType: JavaType,
     if (t == JsonToken.VALUE_NULL) {
       getNullValue(ctxt)
     } else {
-      typeDeserializer.deserializeTypedFromAny(jp, ctxt).asInstanceOf[Option[AnyRef]]
+      val value = valueTypeDeserializer.get.deserializeTypedFromAny(jp, ctxt)
+      Some(value)
     }
   }
 }


### PR DESCRIPTION
See issue #382.

I'm using `valueTypeDeserializer.get` and then wrap the result in `Some`, instead of just using `map`, so that it'd crash if there's no `valueTypeDeserializer`. I don't know if that situation is possible, and there are no failing tests.