### PR TITLE
prepare Scala 2.13

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
@@ -11,8 +11,8 @@ object OrderingLocator {
     classOf[Short] -> Ordering.Short,
     classOf[Int] -> Ordering.Int,
     classOf[Long] -> Ordering.Long,
-    classOf[Float] -> Ordering.Float,
-    classOf[Double] -> Ordering.Double,
+    classOf[Float] -> implicitly[Ordering[Float]],
+    classOf[Double] -> implicitly[Ordering[Double]],
     classOf[BigInt] -> Ordering.BigInt,
     classOf[BigDecimal] -> Ordering.BigDecimal,
     classOf[String] -> Ordering.String


### PR DESCRIPTION
object `Ordering.Float` no longer `Ordering[Float]`

see https://github.com/scala/scala/commit/b686173d5cef2c1cce7b808cc1dfe525f64f794c