### PR TITLE
uptake scala 2.13.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "com.fasterxml.jackson.module"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.6", "2.13.0-M4")
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.6", "2.13.0-M5")
 
 val scalaMajorVersion = SettingKey[Int]("scalaMajorVersion")
 scalaMajorVersion := {
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % "test",
     "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion % "test",
-    "org.scalatest" %% "scalatest" % "3.0.6-SNAP1" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.6-SNAP3" % "test",
     "junit" % "junit" % "4.12" % "test"
 )
 

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -14,8 +14,6 @@ package object deser {
   object overrides {
     // Added in 2.13
     type ArrayDeque[+A] = Iterable[A]
-    type ChampHashMap[A, B] = Map[A, B]
-    type ChampHashSet[A] = Set[A]
     type LazyList[+A] = Stream[A]
     type TrieMap[A, B] = Map[A, B]
 

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -14,8 +14,6 @@ package object deser {
   object overrides {
     // Added in 2.13
     type ArrayDeque[+A] = Iterable[A]
-    type ChampHashMap[A, B] = Map[A, B]
-    type ChampHashSet[A] = Set[A]
     type LazyList[+A] = Stream[A]
     type TrieMap[A, B] = Map[A, B]
 

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -14,8 +14,6 @@ package object deser {
   object overrides {
     // Added in 2.13
     type ArrayDeque[+A] = Iterable[A]
-    type ChampHashMap[A, B] = Map[A, B]
-    type ChampHashSet[A] = Set[A]
     type LazyList[+A] = Stream[A]
     type TrieMap[A, B] = Map[A, B]
 

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -14,7 +14,6 @@ trait UnsortedMapDeserializerModule extends MapTypeModifierModule {
 
     override val factories: List[(Class[_], Factory)] = new MapFactorySorter[Collection, MapFactory]()
       .add(Map)
-      .add(immutable.ChampHashMap)
       .add(immutable.HashMap)
       .add(immutable.ListMap)
       .add(immutable.Map)

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -13,7 +13,6 @@ trait UnsortedSetDeserializerModule extends ScalaTypeModifierModule {
 
     override val factories: Iterable[(Class[_], Factory)] = new FactorySorter[Collection, IterableFactory]()
       .add(Set)
-      .add(immutable.ChampHashSet)
       .add(immutable.HashSet)
       .add(immutable.ListSet)
       .add(immutable.Set)

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -9,8 +9,8 @@ package object deser {
   object overrides {
     // Added in 2.13
     type ArrayDeque[A] = mutable.ArrayDeque[A]
-    type ChampHashMap[A, B] = immutable.ChampHashMap[A, B]
-    type ChampHashSet[A] = immutable.ChampHashSet[A]
+    type ChampHashMap[A, B] = immutable.HashMap[A, B]
+    type ChampHashSet[A] = immutable.HashSet[A]
     type TrieMap[A, B] = concurrent.TrieMap[A, B]
 
     // Mutable versions of these were added in 2.12

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -9,8 +9,6 @@ package object deser {
   object overrides {
     // Added in 2.13
     type ArrayDeque[A] = mutable.ArrayDeque[A]
-    type ChampHashMap[A, B] = immutable.HashMap[A, B]
-    type ChampHashSet[A] = immutable.HashSet[A]
     type TrieMap[A, B] = concurrent.TrieMap[A, B]
 
     // Mutable versions of these were added in 2.12

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
@@ -61,12 +61,6 @@ class UnsortedMapDeserializerTest extends DeserializerTest {
     result should equal (mapScala)
   }
 
-  it should "deserialize an object into an immutable ChampHashMap" in {
-    import overrides._
-    val result = deserialize[ChampHashMap[String, String]](mapJson)
-    result should equal (mapScala)
-  }
-
   it should "deserialize an object into a concurrent TrieMap" in {
     import overrides._
     val result = deserialize[TrieMap[String, String]](mapJson)

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
@@ -39,12 +39,6 @@ class UnsortedSetDeserializerTest extends DeserializerTest {
     result should equal(setScala)
   }
 
-  it should "deserialize an object into an immutable ChampHashSet" in {
-    import overrides._
-    val result = deserialize[ChampHashSet[String]](setJson)
-    result should equal(setScala)
-  }
-
   it should "deserialize an object into an immutable ListSet" in {
     val result = deserialize[immutable.ListSet[String]](setJson)
     result should equal(setScala)


### PR DESCRIPTION
ChampHashMap and ChampHashSet are not renamed HashMap and HashSet
https://contributors.scala-lang.org/t/champhashmap-champhashset-changes-in-2-13-0-m5/2445

https://github.com/FasterXML/jackson-module-scala/issues/391