### PR TITLE
adapt to upcoming change in Scala 2.13

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
@@ -61,7 +61,7 @@ trait JacksonModule extends Module {
         throw new JsonMappingException(null, databindVersionError)
     }
 
-    initializers result() foreach (_ apply context)
+    initializers.result.foreach(_ apply context)
   }
 
   protected def +=(init: SetupContext => Unit): this.type = { initializers += init; this }


### PR DESCRIPTION
`a b()` is no longer accepted

this turned up in the Scala 2.13 community build