### PR TITLE
Fix scala 2.13 compile issue in new test

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/ListMapTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/ListMapTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.junit.JUnitRunner
 
-import scala.collection.immutable.{ListMap, Queue, Stack, TreeMap}
+import scala.collection.immutable.{ListMap, Queue, TreeMap}
 
 // taken from https://github.com/dejanlokar1/serialization_problem/blob/master/src/test/scala/SerializationTest.scala
 // test for https://github.com/FasterXML/jackson-databind/issues/2422
@@ -54,7 +54,6 @@ class ListMapTest extends FlatSpec with Matchers with TableDrivenPropertyChecks 
     val sequences = Table(
       "Sequence implementations",
       List("foo"),
-      Stack("foo"),
       Stream("foo"),
       Queue("foo"),
       Vector("foo")


### PR DESCRIPTION
A new test that I added in https://github.com/FasterXML/jackson-module-scala/pull/420 does not compile in scala 2.13 (apologies).

This PR removes the import that fails.

The scala 2.11 and scala 2.10 builds in travis are also failing but the tests pass for me locally for both of these scala versions.