### PR TITLE
shade jackson-module-scala for version 2.9.10-fs0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ project/boot
 project/target
 target
 logs
+lib/*
 
 # IDEA
 *.iml

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import java.io.File
 // Basic facts
 name := "jackson-module-scala"
 
-organization := "com.fasterxml.jackson.module"
+organization := "__foursquare_shaded__.com.fasterxml.jackson.module"
 
-scalaVersion := "2.12.10"
+scalaVersion := "2.11.12"
 
 crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.10", "2.13.1")
 
@@ -32,21 +32,33 @@ unmanagedSourceDirectories in Compile += {
 val jacksonVersion = "2.9.10"
 
 libraryDependencies ++= Seq(
-  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.module" % "jackson-module-paranamer" % jacksonVersion,
   // test dependencies
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % "test",
-  "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion % "test",
+  "com.google.guava" % "guava" % "18.0" % "test",
+  "joda-time" % "joda-time" % "2.7" % "test",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "junit" % "junit" % "4.12" % "test"
 )
 
+// NOTE(jacob): If re-patching, you will need to drop copies of our shaded jackson jar
+//    into the repo's top-level 'lib' directory for sbt to find them.
+unmanagedBase := file("lib")
+
+excludeDependencies ++= Seq(
+  // provided by shaded jackson fat jars
+  SbtExclusionRule("com.fasterxml.jackson.core", "jackson-core"),
+  SbtExclusionRule("com.fasterxml.jackson.core", "jackson-annotations"),
+  SbtExclusionRule("com.fasterxml.jackson.core", "jackson-databind"),
+  SbtExclusionRule("com.fasterxml.jackson.datatype", "jackson-datatype-guava"),
+  SbtExclusionRule("com.fasterxml.jackson.datatype", "jackson-datatype-joda"),
+  SbtExclusionRule("com.fasterxml.jackson.module", "jackson-module-jsonSchema"),
+  SbtExclusionRule("com.fasterxml.jackson.module", "jackson-module-paranamer")
+)
+
 // build.properties
 resourceGenerators in Compile += Def.task {
-  val file = (resourceManaged in Compile).value / "com" / "fasterxml" / "jackson" / "module" / "scala" / "build.properties"
+  // NOTE(jacob): This file is read at runtime using the shaded package namespace, see
+  //    src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala for details.
+  val file = (resourceManaged in Compile).value / "__foursquare_shaded__" / "com" / "fasterxml" / "jackson" / "module" / "scala" / "build.properties"
   val contents = "version=%s\ngroupId=%s\nartifactId=%s\n".format(version.value, organization.value, name.value)
   IO.write(file, contents)
   Seq(file)

--- a/src/main/java/com/fasterxml/jackson/module/scala/JsonScalaEnumeration.java
+++ b/src/main/java/com/fasterxml/jackson/module/scala/JsonScalaEnumeration.java
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
-import com.fasterxml.jackson.core.type.TypeReference;
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JacksonAnnotation;
+import __foursquare_shaded__.com.fasterxml.jackson.core.type.TypeReference;
 import scala.Enumeration;
 
 import java.lang.annotation.ElementType;

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 import scala.reflect.ClassTag

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.OrderingLocator
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.SortedMapFactory

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.GenMapFactory

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.generic.{GenericCompanion, SortedSetFactory}
 import scala.collection.{GenTraversable, SortedSet, SortedSetLike, immutable, mutable}

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/modifiers/package.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/modifiers/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.{GenMap, GenTraversableOnce}
 

--- a/src/main/scala-2.10/com/fasterxml/jackson/module/scala/ser/package.scala
+++ b/src/main/scala-2.10/com/fasterxml/jackson/module/scala/ser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.language.implicitConversions
 

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 import scala.reflect.ClassTag

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.OrderingLocator
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.SortedMapFactory

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.GenMapFactory

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.generic.{GenericCompanion, SortedSetFactory}
 import scala.collection.{GenTraversable, SortedSet, SortedSetLike, immutable, mutable}

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/modifiers/package.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/modifiers/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.{GenMap, GenTraversableOnce}
 

--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/ser/package.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/ser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.language.implicitConversions
 

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 import scala.reflect.ClassTag

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.OrderingLocator
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.SortedMapFactory

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.collection.generic.GenMapFactory

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.generic.{GenericCompanion, SortedSetFactory}
 import scala.collection.{GenTraversable, SortedSet, SortedSetLike, mutable, immutable}

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/modifiers/package.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/modifiers/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.{GenMap, GenTraversableOnce}
 

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/ser/package.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/ser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.language.implicitConversions
 

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/SeqDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 import scala.reflect.ClassTag

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.OrderingLocator
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.language.existentials

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.MapFactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.MapFactorySorter
 
 import scala.collection._
 import scala.language.existentials

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.collection.{concurrent, immutable, mutable}
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
-import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
 
 /**
  * Complete module with support for all features.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/EitherModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/EitherModule.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.EitherDeserializerModule
-import com.fasterxml.jackson.module.scala.ser.EitherSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EitherDeserializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.EitherSerializerModule
 
 trait EitherModule extends EitherDeserializerModule with EitherSerializerModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/EnumerationModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/EnumerationModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerModule
-import com.fasterxml.jackson.module.scala.ser.EnumerationSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.EnumerationSerializerModule
 
 /**
  * Adds serialization and deserization support for Scala Enumerations.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/IterableModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/IterableModule.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.ser.IterableSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.IterableSerializerModule
 
 /**
  * Adds support for serializing Scala Iterables.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/IteratorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/IteratorModule.scala
@@ -1,5 +1,5 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.ser.IteratorSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.IteratorSerializerModule
 
 trait IteratorModule extends IteratorSerializerModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala
@@ -1,14 +1,14 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import java.util.Properties
 
-import com.fasterxml.jackson.core.Version
-import com.fasterxml.jackson.core.util.VersionUtil
-import com.fasterxml.jackson.databind.Module.SetupContext
-import com.fasterxml.jackson.databind.`type`.TypeModifier
-import com.fasterxml.jackson.databind.deser.Deserializers
-import com.fasterxml.jackson.databind.ser.{BeanSerializerModifier, Serializers}
-import com.fasterxml.jackson.databind.{JsonMappingException, Module}
+import __foursquare_shaded__.com.fasterxml.jackson.core.Version
+import __foursquare_shaded__.com.fasterxml.jackson.core.util.VersionUtil
+import __foursquare_shaded__.com.fasterxml.jackson.databind.Module.SetupContext
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.TypeModifier
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.Deserializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.{BeanSerializerModifier, Serializers}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonMappingException, Module}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/src/main/scala/com/fasterxml/jackson/module/scala/MapModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/MapModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.{SortedMapDeserializerModule, UnsortedMapDeserializerModule}
-import com.fasterxml.jackson.module.scala.ser.MapSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.{SortedMapDeserializerModule, UnsortedMapDeserializerModule}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.MapSerializerModule
 
 trait MapModule
   extends MapSerializerModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/OptionModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/OptionModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.OptionDeserializerModule
-import com.fasterxml.jackson.module.scala.ser.OptionSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.OptionDeserializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.OptionSerializerModule
 
 /**
  * Adds support for serializing and deserializing Scala Options.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/SeqModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/SeqModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.SeqDeserializerModule
-import com.fasterxml.jackson.module.scala.ser.IterableSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.SeqDeserializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.IterableSerializerModule
 
 /**
  * Adds support for serializing and deserializing Scala sequences.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/SetModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/SetModule.scala
@@ -1,5 +1,5 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.{SortedSetDeserializerModule, UnsortedSetDeserializerModule}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.{SortedSetDeserializerModule, UnsortedSetDeserializerModule}
 
 trait SetModule extends UnsortedSetDeserializerModule with SortedSetDeserializerModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/TupleModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/TupleModule.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.TupleDeserializerModule
-import com.fasterxml.jackson.module.scala.ser.TupleSerializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.TupleDeserializerModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.TupleSerializerModule
 
 /**
  * Adds support for serializing and deserializing Scala Tuples.

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/EitherDeserializer.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/EitherDeserializer.scala
@@ -1,12 +1,12 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.deser._
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
-import com.fasterxml.jackson.module.scala.JacksonModule
-import com.fasterxml.jackson.module.scala.deser.EitherDeserializer.ElementDeserializerConfig
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EitherDeserializer.ElementDeserializerConfig
 
 private class EitherDeserializer(javaType: JavaType,
                                  config: DeserializationConfig,

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/EnumerationDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/EnumerationDeserializerModule.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 package deser
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, ContextualKeyDeserializer, Deserializers, KeyDeserializers}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.util.EnumResolver
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{ContextualDeserializer, ContextualKeyDeserializer, Deserializers, KeyDeserializers}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.EnumResolver
 
 private trait ContextualEnumerationDeserializer extends ContextualDeserializer {
   self: JsonDeserializer[Enumeration#Value] =>

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -1,13 +1,13 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.CollectionLikeType
-import com.fasterxml.jackson.databind.deser.std.{CollectionDeserializer, ContainerDeserializerBase, StdValueInstantiator}
-import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.{CollectionDeserializer, ContainerDeserializerBase, StdValueInstantiator}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 
 import scala.collection.mutable
 import scala.language.higherKinds

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericMapFactoryDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericMapFactoryDeserializerResolver.scala
@@ -1,11 +1,11 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.MapLikeType
-import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
-import com.fasterxml.jackson.databind.deser.std.{ContainerDeserializerBase, MapDeserializer, StdValueInstantiator}
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.MapLikeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.{ContainerDeserializerBase, MapDeserializer, StdValueInstantiator}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 
 import scala.collection.mutable
 import scala.language.higherKinds

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerModule.scala
@@ -1,12 +1,12 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.{ReferenceType, TypeFactory}
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers}
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
-import com.fasterxml.jackson.module.scala.modifiers.OptionTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.{ReferenceType, TypeFactory}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.OptionTypeModifierModule
 
 private class OptionDeserializer(fullType: JavaType,
                                  valueTypeDeserializer: Option[TypeDeserializer],

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaNumberDeserializersModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaNumberDeserializersModule.scala
@@ -1,13 +1,13 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package deser
 
-import com.fasterxml.jackson.core.JsonToken.{START_ARRAY, VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT, VALUE_STRING}
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind.DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS
-import com.fasterxml.jackson.databind.deser.Deserializers
-import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
-import com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonToken.{START_ARRAY, VALUE_NUMBER_FLOAT, VALUE_NUMBER_INT, VALUE_STRING}
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.Deserializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
 
 import scala.reflect.{ClassTag, classTag}
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.module.scala.introspect.OrderingLocator
-import com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.FactorySorter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.OrderingLocator
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.ScalaTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.FactorySorter
 
 import scala.collection._
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerModule.scala
@@ -1,11 +1,11 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.deser.{BeanDeserializerFactory, ContextualDeserializer, Deserializers}
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{BeanDeserializerFactory, ContextualDeserializer, Deserializers}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 
 private class TupleDeserializer(javaType: JavaType,
                                 config: DeserializationConfig,

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerModule.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.deser.{Deserializers, std}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.{Deserializers, std}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 
 object UntypedObjectDeserializer
 {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/experimental/RequiredPropertiesSchemaModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/experimental/RequiredPropertiesSchemaModule.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.experimental
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.introspect.{AnnotatedMember, NopAnnotationIntrospector}
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty
+import __foursquare_shaded__.com.fasterxml.jackson.databind.introspect.{AnnotatedMember, NopAnnotationIntrospector}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 
 object DefaultRequiredAnnotationIntrospector extends NopAnnotationIntrospector {
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapper.scala
@@ -1,12 +1,12 @@
-package com.fasterxml.jackson.module.scala.experimental
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental
 
 import java.io._
 import java.net.URL
 
-import com.fasterxml.jackson.core._
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper
-import com.fasterxml.jackson.databind.jsonschema.JsonSchema
+import __foursquare_shaded__.com.fasterxml.jackson.core._
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsonschema.JsonSchema
 
 trait ScalaObjectMapper {
   self: ObjectMapper =>

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanDescriptor.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanDescriptor.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
 import scala.language.existentials
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
@@ -21,12 +21,12 @@
  *    limitations under the License.
  */
 
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
 import java.lang.reflect.{Constructor, Field, Method, Modifier}
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.thoughtworks.paranamer.{BytecodeReadingParanamer, CachingParanamer}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty
+import __foursquare_shaded__.com.thoughtworks.paranamer.{BytecodeReadingParanamer, CachingParanamer}
 
 import scala.annotation.tailrec
 import scala.reflect.NameTransformer

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/OrderingLocator.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
-import com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
 
 object OrderingLocator {
   val ORDERINGS = Map.apply[Class[_],Ordering[_]](

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/PropertyDescriptor.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/PropertyDescriptor.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 package introspect
 
 import java.lang.reflect.{AccessibleObject, Constructor, Field, Method}
 
-import com.fasterxml.jackson.module.scala.util.Implicits._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.Implicits._
 
 import scala.language.existentials
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -1,14 +1,14 @@
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
 import java.lang.annotation.Annotation
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.`type`.ClassKey
-import com.fasterxml.jackson.databind.introspect._
-import com.fasterxml.jackson.databind.util.LRUMap
-import com.fasterxml.jackson.module.paranamer.ParanamerAnnotationIntrospector
-import com.fasterxml.jackson.module.scala.JacksonModule
-import com.fasterxml.jackson.module.scala.util.Implicits._
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonCreator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.ClassKey
+import __foursquare_shaded__.com.fasterxml.jackson.databind.introspect._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.LRUMap
+import __foursquare_shaded__.com.fasterxml.jackson.module.paranamer.ParanamerAnnotationIntrospector
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.Implicits._
 
 object ScalaAnnotationIntrospector extends NopAnnotationIntrospector
 {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/EitherTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/EitherTypeModifierModule.scala
@@ -1,3 +1,3 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 trait EitherTypeModifierModule extends ScalaTypeModifierModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/IterableTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/IterableTypeModifierModule.scala
@@ -1,3 +1,3 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 trait IterableTypeModifierModule extends ScalaTypeModifierModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/IteratorTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/IteratorTypeModifierModule.scala
@@ -1,3 +1,3 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 trait IteratorTypeModifierModule extends ScalaTypeModifierModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/MapTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/MapTypeModifierModule.scala
@@ -1,3 +1,3 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 trait MapTypeModifierModule extends ScalaTypeModifierModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/OptionTypeModifierModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/OptionTypeModifierModule.scala
@@ -1,3 +1,3 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 trait OptionTypeModifierModule extends ScalaTypeModifierModule

--- a/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/ScalaTypeModifier.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/modifiers/ScalaTypeModifier.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson.module.scala.modifiers
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers
 
 import java.lang.reflect.Type
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.databind.`type`._
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 
 import scala.collection._
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/package.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/package.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module
+package __foursquare_shaded__.com.fasterxml.jackson.module
 
 /**
  * Provides Scala support for the [[http://jackson.codehaus.org Jackson JSON Processor]].

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializer.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializer.scala
@@ -1,15 +1,15 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.ReferenceType
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer
-import com.fasterxml.jackson.databind.ser.impl.{PropertySerializerMap, UnknownSerializer}
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import com.fasterxml.jackson.databind.ser.{ContextualSerializer, Serializers}
-import com.fasterxml.jackson.module.scala.modifiers.EitherTypeModifierModule
-import com.fasterxml.jackson.module.scala.util.Implicits._
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonInclude
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.ReferenceType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.impl.{PropertySerializerMap, UnknownSerializer}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.{ContextualSerializer, Serializers}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.EitherTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.Implicits._
 
 import scala.language.existentials
 
@@ -36,7 +36,7 @@ private class EitherSerializer(left: EitherDetails,
   extends StdSerializer[Either[AnyRef, AnyRef]](classOf[Either[AnyRef, AnyRef]])
     with ContextualSerializer {
 
-  import com.fasterxml.jackson.module.scala.ser.OptionSerializer._
+  import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.OptionSerializer._
 
   protected[this] def withResolved(prop: Option[BeanProperty], newLeft: EitherDetails, newRight: EitherDetails,
                                    contentIncl: Option[JsonInclude.Include]): EitherSerializer = {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerModule.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.ser.{ContextualSerializer, Serializers}
-import com.fasterxml.jackson.module.scala.util.Implicits._
-import com.fasterxml.jackson.module.scala.{JacksonModule, JsonScalaEnumeration}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.{ContextualSerializer, Serializers}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.util.Implicits._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{JacksonModule, JsonScalaEnumeration}
 
 trait ContextualEnumerationSerializer extends ContextualSerializer
 {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerModule.scala
@@ -1,16 +1,16 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package ser
 
 import java.{lang => jl}
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.`type`.CollectionLikeType
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer
-import com.fasterxml.jackson.databind.ser.std.{AsArraySerializerBase, CollectionSerializer}
-import com.fasterxml.jackson.databind.ser.{ContainerSerializer, Serializers}
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.modifiers.IterableTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.{AsArraySerializerBase, CollectionSerializer}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.{ContainerSerializer, Serializers}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.IterableTypeModifierModule
 
 import scala.collection.JavaConverters._
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -1,16 +1,16 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package ser
 
 import java.{lang => jl}
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.CollectionLikeType
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer
-import com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase
-import com.fasterxml.jackson.databind.ser.{Serializers, impl}
-import com.fasterxml.jackson.module.scala.modifiers.IteratorTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.{Serializers, impl}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.IteratorTypeModifierModule
 
 import scala.collection.JavaConverters._
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/MapSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/MapSerializerModule.scala
@@ -1,12 +1,12 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.{MapLikeType, TypeFactory}
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer
-import com.fasterxml.jackson.databind.ser.Serializers
-import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
-import com.fasterxml.jackson.databind.util.StdConverter
-import com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.{MapLikeType, TypeFactory}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.Serializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.StdConverter
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.MapTypeModifierModule
 
 import scala.collection.JavaConverters._
 import scala.collection.Map

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerModule.scala
@@ -1,15 +1,15 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package ser
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.ReferenceType
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer
-import com.fasterxml.jackson.databind.ser.Serializers
-import com.fasterxml.jackson.databind.ser.std.ReferenceTypeSerializer
-import com.fasterxml.jackson.databind.util.NameTransformer
-import com.fasterxml.jackson.module.scala.modifiers.OptionTypeModifierModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.ReferenceType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonSerialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.Serializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.ReferenceTypeSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.NameTransformer
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.modifiers.OptionTypeModifierModule
 
 // This is still here because it is used in other places like EitherSerializer, it is no
 // longer used for the Option serializer

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerModule.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.ser.Serializers
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.Serializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 
 private class TupleSerializer extends JsonSerializer[Product] {
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/Classes.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/Classes.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 import scala.language.implicitConversions
 import scala.reflect.{ScalaLongSignature, ScalaSignature}

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/EnumResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/EnumResolver.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 package util
 
 import java.lang.reflect.ParameterizedType
 
-import com.fasterxml.jackson.databind.BeanProperty
+import __foursquare_shaded__.com.fasterxml.jackson.databind.BeanProperty
 
 object EnumResolver {
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/FactorySorter.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/FactorySorter.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.language.higherKinds

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/Implicits.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/Implicits.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 object Implicits
   extends Classes

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/Options.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/Options.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/PimpedType.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/PimpedType.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/util/Strings.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/util/Strings.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.util
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.util
 
 import scala.language.implicitConversions
 

--- a/src/test/java/com/fasterxml/jackson/module/scala/deser/JavaInteropTest.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/deser/JavaInteropTest.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.deser;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser;
 
 import org.junit.Test;
 

--- a/src/test/java/com/fasterxml/jackson/module/scala/deser/ValueHolder.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/deser/ValueHolder.java
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.deser;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonCreator;
 
 public class ValueHolder {
     public final long internalValue;

--- a/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaFields.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaFields.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.introspect;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect;
 
 public class JavaFields {
     public final String string = "string";

--- a/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaMethods.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaMethods.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.introspect;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect;
 
 public class JavaMethods {
     public String getStuff() { return "stuff"; }

--- a/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaStaticMethods.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/introspect/JavaStaticMethods.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.introspect;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect;
 
 public class JavaStaticMethods {
     public static String getExcludedValue() { return "Should not be serialized"; }

--- a/src/test/java/com/fasterxml/jackson/module/scala/introspect/JsonScalaTestAnnotation.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/introspect/JsonScalaTestAnnotation.java
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.introspect;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JacksonAnnotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/test/java/com/fasterxml/jackson/module/scala/ser/Field.java
+++ b/src/test/java/com/fasterxml/jackson/module/scala/ser/Field.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.ser;
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser;
 
 public class Field {
     public static enum Type {

--- a/src/test/scala/UnpackagedTest.scala
+++ b/src/test/scala/UnpackagedTest.scala
@@ -1,5 +1,5 @@
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.ser.SerializerTest
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.SerializerTest
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/external/CustomScalaModuleTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/external/CustomScalaModuleTest.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.external
+package __foursquare_shaded__.com.fasterxml.jackson.module.external
 
-import com.fasterxml.jackson.module.scala.BaseSpec
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.BaseSpec
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -10,9 +10,9 @@ class CustomScalaModuleTest extends BaseSpec {
     "A custom scala module" should "be buildable outside of the module package" in {
         """
           |
-          |import com.fasterxml.jackson.module.scala._
-          |import com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
-          |import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
+          |import __foursquare_shaded__.com.fasterxml.jackson.module.scala._
+          |import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
+          |import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
           |
           |class CustomScalaModule
           |  extends JacksonModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/BaseFixture.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/BaseFixture.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import org.scalatest.{Matchers, Outcome, fixture}
 
 class BaseFixture extends fixture.FlatSpec with Matchers {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/BaseSpec.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/BaseSpec.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/DefaultScalaModuleTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/DefaultScalaModuleTest.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/EnumContainer.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/EnumContainer.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 import scala.beans.BeanProperty
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/JacksonTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/JacksonTest.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.databind.{Module, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{Module, ObjectMapper}
 
 abstract class JacksonTest extends BaseSpec {
   def module: Module

--- a/src/test/scala/com/fasterxml/jackson/module/scala/OuterWeekday.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/OuterWeekday.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 object OuterWeekday {
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/UnwrappedTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/UnwrappedTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonUnwrapped}
-import com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonIgnore, JsonUnwrapped}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/Weekday.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/Weekday.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala
 
 object Weekday extends Enumeration {
 	type Weekday = Value

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package deser
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper, ObjectReader, PropertyNamingStrategy}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper, ObjectReader, PropertyNamingStrategy}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -43,7 +43,7 @@ object CaseClassDeserializerTest
 
 @RunWith(classOf[JUnitRunner])
 class CaseClassDeserializerTest extends DeserializerTest {
-  import com.fasterxml.jackson.module.scala.deser.CaseClassDeserializerTest._
+  import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.CaseClassDeserializerTest._
 
 
   def module: DefaultScalaModule.type = DefaultScalaModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CreatorTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CreatorTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonCreator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializationFixture.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializationFixture.scala
@@ -1,5 +1,5 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.module.scala.BaseFixture
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.BaseFixture
 
 class DeserializationFixture extends BaseFixture

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.lang.reflect.{ParameterizedType, Type}
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.module.scala.JacksonTest
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonTest
 
 trait DeserializerTest extends JacksonTest {
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/EitherDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/EitherDeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.annotation._
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.deser.EitherJsonTest.{BaseHolder, EitherField, Impl, PlainPojoObject}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EitherJsonTest.{BaseHolder, EitherField, Impl, PlainPojoObject}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/EnumerationDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/EnumerationDeserializerTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.module.scala.OuterWeekday.InnerWeekday
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration, Weekday}
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.OuterWeekday.InnerWeekday
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration, Weekday}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -32,7 +32,7 @@ object EnumerationDeserializerTest  {
 
 @RunWith(classOf[JUnitRunner])
 class EnumerationDeserializerTest extends DeserializerTest {
-  import com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerTest._
+  import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EnumerationDeserializerTest._
 
   lazy val module: DefaultScalaModule.type = DefaultScalaModule
 
@@ -63,9 +63,9 @@ class EnumerationDeserializerTest extends DeserializerTest {
     result.weekdayMap should contain key Weekday.Mon
   }
 
-  val fridayEnumJson = """{"day": {"enumClass":"com.fasterxml.jackson.module.scala.Weekday","value":"Fri"}}"""
+  val fridayEnumJson = """{"day": {"enumClass":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.Weekday","value":"Fri"}}"""
 
-  val fridayInnerEnumJson = """{"day": {"enumClass":"com.fasterxml.jackson.module.scala.OuterWeekday$InnerWeekday","value":"Fri"}}"""
+  val fridayInnerEnumJson = """{"day": {"enumClass":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.OuterWeekday$InnerWeekday","value":"Fri"}}"""
 
   val annotatedFridayJson = """{"weekday":"Fri"}"""
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/GuavaModuleTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/GuavaModuleTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, ObjectReader}
-import com.fasterxml.jackson.datatype.guava.GuavaModule
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, ObjectReader}
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.guava.GuavaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.collect.Multimap
 import org.junit.Assert.assertNotNull
 import org.junit.Test

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/InteropTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/InteropTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/IterableDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/IterableDeserializerTest.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 class IterableDeserializerTest extends DeserializationFixture {
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/ListMapTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/ListMapTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.io.StringWriter
 
-import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MiscTypesTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MiscTypesTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionDeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo, JsonTypeName}
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo, JsonTypeName}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithJodaTimeDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithJodaTimeDeserializerTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.datatype.joda.JodaModule
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.JodaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/PrimitiveContainerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/PrimitiveContainerTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.JsonMappingException
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonMappingException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqDeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.InvalidFormatException
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedMapDeserializerTest.scala
@@ -1,11 +1,11 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.JsonNodeFactory
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SortedSetDeserializerTest.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.InvalidFormatException
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/StdDeserializersTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/StdDeserializersTest.scala
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/TestInnerClass.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/TestInnerClass.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/TupleDeserializerTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.{As, Id}
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonTypeInfo.{As, Id}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedMapDeserializerTest.scala
@@ -1,11 +1,11 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.JsonNodeFactory
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UnsortedSetDeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
 import java.util.UUID
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.InvalidFormatException
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/UntypedObjectDeserializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.deser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.databind.`type`.MapLikeType
-import com.fasterxml.jackson.databind.{AbstractTypeResolver, DeserializationConfig, JavaType, ObjectMapper}
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.MapLikeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{AbstractTypeResolver, DeserializationConfig, JavaType, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/experimental/EnumMixinTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/experimental/EnumMixinTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.experimental
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration}
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JsonScalaEnumeration}
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/experimental/ScalaObjectMapperTest.scala
@@ -1,12 +1,12 @@
-package com.fasterxml.jackson.module.scala.experimental
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental
 
 import java.io.{ByteArrayInputStream, InputStreamReader}
 
-import com.fasterxml.jackson.annotation.JsonView
-import com.fasterxml.jackson.core.TreeNode
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonView
+import __foursquare_shaded__.com.fasterxml.jackson.core.TreeNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.InvalidFormatException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.junit.JUnitRunner

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospectorTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospectorTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
 import java.lang.reflect.Member
 
-import com.fasterxml.jackson.module.scala.BaseSpec
-import com.fasterxml.jackson.module.scala.introspect.BeanIntrospectorTest.DecodedNameMatcher
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.BaseSpec
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect.BeanIntrospectorTest.DecodedNameMatcher
 import org.junit.runner.RunWith
 import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
 import org.scalatest.{Inside, LoneElement, OptionValues}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorTest.scala
@@ -1,13 +1,13 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package introspect
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.ContextualSerializer
-import com.fasterxml.jackson.databind.{BeanDescription, JsonSerializer, ObjectMapper, SerializerProvider}
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.module.SimpleModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.ContextualSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{BeanDescription, JsonSerializer, ObjectMapper, SerializerProvider}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import org.junit.runner.RunWith
 import org.scalatest.LoneElement._
 import org.scalatest.{Matchers, Outcome, fixture}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestSyntheticBridgeMethods.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/TestSyntheticBridgeMethods.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.introspect
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.introspect
 
-import com.fasterxml.jackson.module.scala.BaseSpec
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.BaseSpec
 import org.scalatest.{Inside, LoneElement}
 
 object TestSyntheticBridgeMethods {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/AnyValSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/AnyValSerializerTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonValue
-import com.fasterxml.jackson.module.scala.BaseFixture
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonValue
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.BaseFixture
 
 import scala.annotation.meta.getter
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonProperty.Access
-import com.fasterxml.jackson.annotation._
-import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty.Access
+import __foursquare_shaded__.com.fasterxml.jackson.annotation._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -145,11 +145,11 @@ class CaseClassSerializerTest extends SerializerTest {
   }
 
   it should "serialize a case class with JsonTypeInfo" in {
-    serialize(JsonTypeInfoCaseClass(1)) should equal( """{"class":"com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}""")
+    serialize(JsonTypeInfoCaseClass(1)) should equal( """{"class":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}""")
   }
 
   it should "serialize a case class containing a case class with JsonTypeInfo" in {
-    serialize(CaseClassContainingJsonTypeInfoCaseClass(JsonTypeInfoCaseClass(1))) should equal( """{"c":{"class":"com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}}""")
+    serialize(CaseClassContainingJsonTypeInfoCaseClass(JsonTypeInfoCaseClass(1))) should equal( """{"c":{"class":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.JsonTypeInfoCaseClass","intValue":1}}""")
   }
 
   it should "serialize a non-case class with @BeanProperty annotations" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseObjectSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseObjectSerializerTest.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/EitherSerializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.scala.deser.EitherJsonTest.{BaseHolder, Impl}
-import com.fasterxml.jackson.module.scala.deser.EitherJsonTestSupport
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EitherJsonTest.{BaseHolder, Impl}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.deser.EitherJsonTestSupport
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/EnumerationSerializerTest.scala
@@ -1,9 +1,9 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package ser
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.module.scala.OuterWeekday.InnerWeekday
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.OuterWeekday.InnerWeekday
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -47,12 +47,12 @@ class EnumerationSerializerTest extends SerializerTest {
 
   it should "serialize an Enumeration" in {
 		val day = Weekday.Fri
-		serialize(day) should be ("""{"enumClass":"com.fasterxml.jackson.module.scala.Weekday","value":"Fri"}""")
+		serialize(day) should be ("""{"enumClass":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.Weekday","value":"Fri"}""")
 	}
 
   it should "serialize an inner Enumeration" in {
     val day = InnerWeekday.Fri
-    serialize(day) should be ("""{"enumClass":"com.fasterxml.jackson.module.scala.OuterWeekday$InnerWeekday","value":"Fri"}""")
+    serialize(day) should be ("""{"enumClass":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.OuterWeekday$InnerWeekday","value":"Fri"}""")
   }
 
   it should "serialize an annotated Enumeration with custom values" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty, JsonTypeInfo}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty, JsonTypeInfo}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatest.matchers.Matcher
 import org.scalatestplus.junit.JUnitRunner
@@ -79,7 +79,7 @@ class IterableSerializerTest extends SerializerTest {
   }
 
   it should "honor JsonTypeInfo" in {
-    serialize(CHolder(Seq[C](X("1"), X("2")))) shouldBe """{"c":[{"@class":"com.fasterxml.jackson.module.scala.ser.IterableSerializerTest$X","data":"1"},{"@class":"com.fasterxml.jackson.module.scala.ser.IterableSerializerTest$X","data":"2"}]}"""
+    serialize(CHolder(Seq[C](X("1"), X("2")))) shouldBe """{"c":[{"@class":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.IterableSerializerTest$X","data":"1"},{"@class":"__foursquare_shaded__.com.fasterxml.jackson.module.scala.ser.IterableSerializerTest$X","data":"2"}]}"""
   }
 
   val matchUnorderedSet: Matcher[Any] = {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/MapSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/MapSerializerTest.scala
@@ -1,11 +1,11 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.{As, Id}
-import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty, JsonSubTypes, JsonTypeInfo}
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import com.fasterxml.jackson.databind.{JsonSerializer, SerializationFeature, SerializerProvider}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonTypeInfo.{As, Id}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty, JsonSubTypes, JsonTypeInfo}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonSerialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonSerializer, SerializationFeature, SerializerProvider}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
@@ -1,10 +1,10 @@
-package com.fasterxml.jackson
+package __foursquare_shaded__.com.fasterxml.jackson
 package module.scala
 package ser
 
 import java.io.ByteArrayOutputStream
 
-import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
 import com.google.common.base.Optional
 import org.junit.runner.RunWith
 import org.scalatest.{Matchers, Outcome, fixture}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/OptionSerializerTest.scala
@@ -1,14 +1,14 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
 import java.util
 
-import com.fasterxml.jackson.annotation._
-import com.fasterxml.jackson.databind.node.JsonNodeType
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import com.fasterxml.jackson.module.jsonSchema.JsonSchema
-import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper
-import com.fasterxml.jackson.module.scala.experimental.{RequiredPropertiesSchemaModule, ScalaObjectMapper}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.JsonNodeType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.jsonSchema.JsonSchema
+import __foursquare_shaded__.com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.{RequiredPropertiesSchemaModule, ScalaObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/SerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/SerializerTest.scala
@@ -1,7 +1,7 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import com.fasterxml.jackson.module.scala.JacksonTest
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonTest
 
 trait SerializerTest extends JacksonTest {
   def serialize(value: Any, mapper: ObjectMapper = newMapper): String = mapper.writeValueAsString(value)

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/TestJsonValue.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/TestJsonValue.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonValue
-import com.fasterxml.jackson.databind.Module
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonValue
+import __foursquare_shaded__.com.fasterxml.jackson.databind.Module
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/TransientFieldTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/TransientFieldTest.scala
@@ -1,8 +1,8 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder
-import com.fasterxml.jackson.databind.MapperFeature
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonPropertyOrder
+import __foursquare_shaded__.com.fasterxml.jackson.databind.MapperFeature
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonModule}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/TupleSerializerTest.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.module.scala.ser
+package __foursquare_shaded__.com.fasterxml.jackson.module.scala.ser
 
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.9.10-SNAPSHOT"
+version in ThisBuild := "2.9.10-fs0"


### PR DESCRIPTION
There are a handful of steps involved here:

 0. add our shaded core jackson fat jar and shaded test jackson jar
    (required only for running the tests here) to the repo's top-
    level lib directory (they are unmanaged dependencies in sbt's
    eyes)
 1. update build configuration to ban upstream jackson jars
 2. update core jackson imports to use their shaded variants
 3. shade jackson-module-scala package namespace
 4. update some hard-coded package name strings in tests
 5. run tests
 6. bump the version in `version.sbt` and publish the shaded jar. For
    whatever asinine reason, publishLocal here builds the javadoc,
    sources, and pom correctly but constructs a compiled jar bereft
    of actual class files. My workaround for this was to publishLocal
    first and then package
 7. test using the shaded jar locally
 8. upload the shaded jar, javadoc, sources, and pom to artifactory.
    if we are still on scala 2.11, upload the 2.12 jars as well.
 9. make a new branch on our github fork off the upstream release tag
    (call it something like 2.9-fs), open a pr against that for
    review, then merge your changes and push a new git tag for the
    patch release (eg. jackson-module-scala-2.9.10-fs0)

Code-wise, this is a dead simple namespace refactor. Unfortunately,
most of the complexity involved comes at runtime in the form of
manually validating the classpath is properly constructed. The repo's
test suite certainly helps and is a good place to start, however some
other checks to make:

 - in sbt, run `show test:fullClasspath` and verify it shows no
   versions of jackson other than our shaded fat jar
 - after packaging the shaded jar, unzip it and verify it contains
   only shaded jackson-module-scala class files
 - as an added sanity check, always unzip our shaded core jackson fat
   jar and make sure it doesn't include unshaded class files either

Assuming you have done your due diligence on all of the above, your
newly shaded jar should be good to go!