### PR TITLE
Add merge support for Scala collections

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -48,6 +48,8 @@ abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deser
 
     // Required by AbstractCollection, but not implemented
     override def iterator(): util.Iterator[A] = None.orNull
+
+    def setInitialValue(init: Collection[_]): Unit = init.asInstanceOf[Iterable[A]].foreach(add)
   }
 
   private class Instantiator(config: DeserializationConfig, collectionType: JavaType, valueType: JavaType)
@@ -82,9 +84,21 @@ abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deser
       }
     }
 
+    override def deserialize(jp: JsonParser, ctxt: DeserializationContext, intoValue: CC[_]): CC[_] = {
+      val bw = newBuilderWrapper(ctxt)
+      bw.setInitialValue(intoValue)
+      containerDeserializer.deserialize(jp, ctxt, bw) match {
+        case wrapper: BuilderWrapper[_] => wrapper.builder.result()
+      }
+    }
+
     override def getEmptyValue(ctxt: DeserializationContext): Object = {
-      val bw = containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]
+      val bw = newBuilderWrapper(ctxt)
       bw.builder.result().asInstanceOf[Object]
+    }
+
+    private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef] = {
+      containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]
     }
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/DeserializerTest.scala
@@ -12,7 +12,7 @@ trait DeserializerTest extends JacksonTest {
   def deserialize[T: Manifest](value: String) : T =
     newMapper.readValue(value, typeReference[T])
 
-  private [this] def typeReference[T: Manifest]: TypeReference[T] = new TypeReference[T] {
+  def typeReference[T: Manifest]: TypeReference[T] = new TypeReference[T] {
     override def getType: Type = typeFromManifest(manifest[T])
   }
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MergeTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MergeTest.scala
@@ -1,0 +1,103 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.annotation.JsonMerge
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.junit.runner.RunWith
+import org.scalatestplus.junit.JUnitRunner
+
+import scala.collection.{Map, mutable}
+
+case class ClassWithLists(field1: List[String], @JsonMerge field2: List[String])
+case class ClassWithMaps[T](field1: Map[String, T], @JsonMerge field2: Map[String, T])
+case class ClassWithMutableMaps[T](field1: mutable.Map[String, T], @JsonMerge field2: mutable.Map[String, T])
+
+case class Pair(first: String, second: String)
+
+@RunWith(classOf[JUnitRunner])
+class MergeTest extends DeserializerTest {
+
+  val module: DefaultScalaModule.type = DefaultScalaModule
+
+  behavior of "The DefaultScalaModule when reading for updating"
+
+  it should "merge both lists" in {
+    val initial = deserialize[ClassWithLists](classJson(firstListJson))
+    val result = newMapper.setDefaultMergeable(true)
+      .readerForUpdating(initial).readValue[ClassWithLists](classJson(secondListJson))
+
+    result shouldBe ClassWithLists(mergedList, mergedList)
+  }
+
+  it should "merge only the annotated list" in {
+    val initial = deserialize[ClassWithLists](classJson(firstListJson))
+    val result = newMapper
+      .readerForUpdating(initial).readValue[ClassWithLists](classJson(secondListJson))
+
+    result shouldBe ClassWithLists(secondList, mergedList)
+  }
+
+  it should "merge both string maps" in {
+    val initial = deserialize[ClassWithMaps[String]](classJson(firstStringMapJson))
+    val result = newMapper.setDefaultMergeable(true)
+      .readerForUpdating(initial).readValue[ClassWithMaps[String]](classJson(secondStringMapJson))
+
+    result shouldBe ClassWithMaps(mergedStringMap, mergedStringMap)
+  }
+
+  it should "merge only the annotated string map" in {
+    val initial = deserialize[ClassWithMaps[String]](classJson(firstStringMapJson))
+    val result = newMapper
+      .readerForUpdating(initial).readValue[ClassWithMaps[String]](classJson(secondStringMapJson))
+
+    result shouldBe ClassWithMaps(secondStringMap, mergedStringMap)
+  }
+
+  it should "merge both pair maps" in {
+    val initial = deserialize[ClassWithMaps[Pair]](classJson(firstPairMapJson))
+    val result = newMapper.setDefaultMergeable(true)
+      .readerForUpdating(initial).forType(typeReference[ClassWithMaps[Pair]]).readValue[ClassWithMaps[Pair]](classJson(secondPairMapJson))
+
+    result shouldBe ClassWithMaps(mergedPairMap, mergedPairMap)
+  }
+
+  it should "merge only the annotated pair map" in {
+    val initial = deserialize[ClassWithMaps[Pair]](classJson(firstPairMapJson))
+    val result = newMapper
+      .readerForUpdating(initial).forType(typeReference[ClassWithMaps[Pair]]).readValue[ClassWithMaps[Pair]](classJson(secondPairMapJson))
+
+    result shouldBe ClassWithMaps(secondPairMap, mergedPairMap)
+  }
+
+  it should "merge both mutable maps" in {
+    val initial = deserialize[ClassWithMutableMaps[String]](classJson(firstStringMapJson))
+    val result = newMapper.setDefaultMergeable(true)
+      .readerForUpdating(initial).readValue[ClassWithMutableMaps[String]](classJson(secondStringMapJson))
+
+    result shouldBe ClassWithMutableMaps(mutable.Map() ++ mergedStringMap, mutable.Map() ++ mergedStringMap)
+  }
+
+  it should "merge only the annotated mutable map" in {
+    val initial = deserialize[ClassWithMutableMaps[String]](classJson(firstStringMapJson))
+    val result = newMapper
+      .readerForUpdating(initial).readValue[ClassWithMutableMaps[String]](classJson(secondStringMapJson))
+
+    result shouldBe ClassWithMutableMaps(mutable.Map() ++ secondStringMap, mutable.Map() ++ mergedStringMap)
+  }
+
+  def classJson(nestedJson: String) = s"""{"field1":$nestedJson,"field2":$nestedJson}"""
+
+  val firstListJson = """["one","two"]"""
+  val secondListJson = """["three"]"""
+  val secondList = List("three")
+  val mergedList = List("one", "two", "three")
+
+  val firstStringMapJson = """{"one":"1","two":"2"}"""
+  val secondStringMapJson = """{"two":"22","three":"33"}"""
+  val secondStringMap = Map("two" -> "22", "three" -> "33")
+  val mergedStringMap = Map("one" -> "1", "two" -> "22", "three" -> "33")
+
+  val firstPairMapJson = """{"one":{"first":"1"},"two":{"second":"2"},"three":{"first":"3","second":"4"}}"""
+  val secondPairMapJson = """{"two":{"first":"22"},"three":{"second":"33"}}"""
+  val secondPairMap = Map("two" -> Pair("22", null), "three" -> Pair(null, "33"))
+  val mergedPairMap = Map("one" -> Pair("1", null), "two" -> Pair("22", "2"), "three" -> Pair("3", "33"))
+}


### PR DESCRIPTION
This PR adds support for Jackson's merge feature to Scala collection deserializers. Closes #370 

Not sure if this is the best way to go about it, but it's working properly in the examples I've tried. Merge support is done by implementing the method `JsonDeserializer.deserialize(JsonParser p, DeserializationContext ctxt, T intoValue)` which takes the previous value to be updated/merged with the new fields coming from JSON. Support for Scala's Maps is particularly tricky because `GenericMapFactoryDeserializerResolver` is based on `MapDeserializer` which tries to access `Map.get(...)` for deep merging, but Scala's `Builder` doesn't have a get, so it wasn't straightforward to add a `get` to `BuilderWrapper`.