### PR TITLE
Add updateValue to ScalaObjectMapper

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/ScalaObjectMapper.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ScalaObjectMapper.scala
@@ -207,6 +207,38 @@ trait ScalaObjectMapper {
     readValue(src, offset, len, constructType[T])
   }
 
+  def updateValue[T: Manifest](valueToUpdate: T, src: File): T = {
+    objectReaderFor(valueToUpdate).readValue(src)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, src: URL): T = {
+    objectReaderFor(valueToUpdate).readValue(src)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, content: String): T = {
+    objectReaderFor(valueToUpdate).readValue(content)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, src: Reader): T = {
+    objectReaderFor(valueToUpdate).readValue(src)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, src: InputStream): T = {
+    objectReaderFor(valueToUpdate).readValue(src)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, src: Array[Byte]): T = {
+    objectReaderFor(valueToUpdate).readValue(src)
+  }
+
+  def updateValue[T: Manifest](valueToUpdate: T, src: Array[Byte], offset: Int, len: Int): T = {
+    objectReaderFor(valueToUpdate).readValue(src, offset, len)
+  }
+
+  private def objectReaderFor[T: Manifest](valueToUpdate: T): ObjectReader = {
+    readerForUpdating(valueToUpdate).forType(constructType[T])
+  }
+
   /*
    **********************************************************
    * Extended Public API: constructing ObjectWriters

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ScalaObjectMapperTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ScalaObjectMapperTest.scala
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.module.scala
 
-import java.io.{ByteArrayInputStream, InputStreamReader}
+import java.io.{ByteArrayInputStream, File, InputStreamReader}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import com.fasterxml.jackson.annotation.JsonView
 import com.fasterxml.jackson.core.TreeNode
@@ -89,6 +91,20 @@ class ScalaObjectMapperTest extends BaseSpec {
   it should "know if it can deserialize a deserializable type" in {
     val result = mapper.canDeserialize[Target]
     result should equal(mapper.canDeserialize(mapper.constructType(classOf[Target])))
+  }
+
+  it should "read value from file" in {
+    withFile(genericJson) { file =>
+      val result = mapper.readValue[GenericTestClass[Int]](file)
+      result should equal(genericInt)
+    }
+  }
+
+  it should "read value from URL" in {
+    withFile(genericJson) { file =>
+      val result = mapper.readValue[GenericTestClass[Int]](file.toURI.toURL)
+      result should equal(genericInt)
+    }
   }
 
   it should "read value from string" in {
@@ -211,9 +227,48 @@ class ScalaObjectMapperTest extends BaseSpec {
     result(1) should equal(None)
   }
 
+  it should "update value from file" in {
+    withFile(toplevelArrayJson) { file =>
+      val result = mapper.updateValue(List.empty[GenericTestClass[Int]], file)
+      result should equal(listGenericInt)
+    }
+  }
+
+  it should "update value from URL" in {
+    withFile(toplevelArrayJson) { file =>
+      val result = mapper.updateValue(List.empty[GenericTestClass[Int]], file.toURI.toURL)
+      result should equal(listGenericInt)
+    }
+  }
+
+  it should "update value from string" in {
+    val result = mapper.updateValue(List.empty[GenericTestClass[Int]], toplevelArrayJson)
+    result should equal(listGenericInt)
+  }
+
+  it should "update value from Reader" in {
+    val reader = new InputStreamReader(new ByteArrayInputStream(toplevelArrayJson.getBytes))
+    val result = mapper.updateValue(List.empty[GenericTestClass[Int]], reader)
+    result should equal(listGenericInt)
+  }
+
+  it should "update value from stream" in {
+    val stream = new ByteArrayInputStream(toplevelArrayJson.getBytes)
+    val result = mapper.updateValue(List.empty[GenericTestClass[Int]], stream)
+    result should equal(listGenericInt)
+  }
+
+  it should "update value from byte array" in {
+    val result = mapper.updateValue(List.empty[GenericTestClass[Int]], toplevelArrayJson.getBytes)
+    result should equal(listGenericInt)
+  }
+
+  it should "update value from subset of byte array" in {
+    val result = mapper.updateValue(List.empty[GenericTestClass[Int]], toplevelArrayJson.getBytes, 0, toplevelArrayJson.length)
+    result should equal(listGenericInt)
+  }
+
   // No tests for the following functions:
-  //  def readValue[T: Manifest](src: File): T
-  //  def readValue[T: Manifest](src: URL): T
   //  def acceptJsonFormatVisitor[T: Manifest](visitor: JsonFormatVisitorWrapper): Unit
 
   private val genericJson = """{"t":42}"""
@@ -224,4 +279,18 @@ class ScalaObjectMapperTest extends BaseSpec {
   private val genericMixedFieldJson = """{"first":"firstVal","second":2}"""
   private val toplevelArrayJson = """[{"t":42},{"t":31}]"""
   private val toplevelOptionArrayJson = """["some",null]"""
+
+  private def withFile[T](contents: String)(body: File => T): T = {
+    val file = File.createTempFile("jackson_scala_test", getClass.getSimpleName)
+    try {
+      Files.write(file.toPath, contents.getBytes(StandardCharsets.UTF_8))
+      body(file)
+    } finally {
+      try {
+        file.delete()
+      } catch {
+        case _: Exception => // ignore
+      }
+    }
+  }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MergeTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MergeTest.scala
@@ -1,7 +1,8 @@
 package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.annotation.JsonMerge
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 
@@ -18,68 +19,72 @@ class MergeTest extends DeserializerTest {
 
   val module: DefaultScalaModule.type = DefaultScalaModule
 
+  def newScalaMapper: ObjectMapper with ScalaObjectMapper = {
+    val mapper = new ObjectMapper with ScalaObjectMapper
+    mapper.registerModule(module)
+    mapper
+  }
+
+  def newMergeableScalaMapper: ObjectMapper with ScalaObjectMapper = {
+    val mapper = newScalaMapper
+    mapper.setDefaultMergeable(true)
+    mapper
+  }
+
   behavior of "The DefaultScalaModule when reading for updating"
 
   it should "merge both lists" in {
     val initial = deserialize[ClassWithLists](classJson(firstListJson))
-    val result = newMapper.setDefaultMergeable(true)
-      .readerForUpdating(initial).readValue[ClassWithLists](classJson(secondListJson))
+    val result = newMergeableScalaMapper.updateValue(initial, classJson(secondListJson))
 
     result shouldBe ClassWithLists(mergedList, mergedList)
   }
 
   it should "merge only the annotated list" in {
     val initial = deserialize[ClassWithLists](classJson(firstListJson))
-    val result = newMapper
-      .readerForUpdating(initial).readValue[ClassWithLists](classJson(secondListJson))
+    val result = newScalaMapper.updateValue(initial, classJson(secondListJson))
 
     result shouldBe ClassWithLists(secondList, mergedList)
   }
 
   it should "merge both string maps" in {
     val initial = deserialize[ClassWithMaps[String]](classJson(firstStringMapJson))
-    val result = newMapper.setDefaultMergeable(true)
-      .readerForUpdating(initial).readValue[ClassWithMaps[String]](classJson(secondStringMapJson))
+    val result = newMergeableScalaMapper.updateValue(initial, classJson(secondStringMapJson))
 
     result shouldBe ClassWithMaps(mergedStringMap, mergedStringMap)
   }
 
   it should "merge only the annotated string map" in {
     val initial = deserialize[ClassWithMaps[String]](classJson(firstStringMapJson))
-    val result = newMapper
-      .readerForUpdating(initial).readValue[ClassWithMaps[String]](classJson(secondStringMapJson))
+    val result = newScalaMapper.updateValue(initial, classJson(secondStringMapJson))
 
     result shouldBe ClassWithMaps(secondStringMap, mergedStringMap)
   }
 
   it should "merge both pair maps" in {
     val initial = deserialize[ClassWithMaps[Pair]](classJson(firstPairMapJson))
-    val result = newMapper.setDefaultMergeable(true)
-      .readerForUpdating(initial).forType(typeReference[ClassWithMaps[Pair]]).readValue[ClassWithMaps[Pair]](classJson(secondPairMapJson))
+    val result = newMergeableScalaMapper.updateValue(initial, classJson(secondPairMapJson))
 
     result shouldBe ClassWithMaps(mergedPairMap, mergedPairMap)
   }
 
   it should "merge only the annotated pair map" in {
     val initial = deserialize[ClassWithMaps[Pair]](classJson(firstPairMapJson))
-    val result = newMapper
-      .readerForUpdating(initial).forType(typeReference[ClassWithMaps[Pair]]).readValue[ClassWithMaps[Pair]](classJson(secondPairMapJson))
+    val result = newScalaMapper.updateValue(initial, classJson(secondPairMapJson))
 
     result shouldBe ClassWithMaps(secondPairMap, mergedPairMap)
   }
 
   it should "merge both mutable maps" in {
     val initial = deserialize[ClassWithMutableMaps[String]](classJson(firstStringMapJson))
-    val result = newMapper.setDefaultMergeable(true)
-      .readerForUpdating(initial).readValue[ClassWithMutableMaps[String]](classJson(secondStringMapJson))
+    val result = newMergeableScalaMapper.updateValue(initial, classJson(secondStringMapJson))
 
     result shouldBe ClassWithMutableMaps(mutable.Map() ++ mergedStringMap, mutable.Map() ++ mergedStringMap)
   }
 
   it should "merge only the annotated mutable map" in {
     val initial = deserialize[ClassWithMutableMaps[String]](classJson(firstStringMapJson))
-    val result = newMapper
-      .readerForUpdating(initial).readValue[ClassWithMutableMaps[String]](classJson(secondStringMapJson))
+    val result = newScalaMapper.updateValue(initial, classJson(secondStringMapJson))
 
     result shouldBe ClassWithMutableMaps(mutable.Map() ++ secondStringMap, mutable.Map() ++ mergedStringMap)
   }


### PR DESCRIPTION
This is more of a proposal at this stage to add `updateValue` methods to `ScalaObjectMapper` as a parallel to `readValue` methods. PRs might not be the best approach to discuss new proposals, but since I started trying it out to figure out if it would work the way I thought, I might as well share the idea through code.

This would remove a lot of boilerplate when using `readerForUpdating` feature. For simple types it's already not ideal as we have to repeat the type signature in `readValue` when it's already known from `valueToUpdate`, but for more complex types it gets rather annoying having to repeat the type yet another time through `forType` method.

Taking the example from the test, it's the difference between just writting:
```
val result = mapper.updateValue(List.empty[GenericTestClass[Int]], toplevelArrayJson)
```

Versus having to write this:
```
val result = mapper.readerForUpdating(List.empty[GenericTestClass[Int]])
    .forType(mapper.constructType[List[GenericTestClass[Int]]])
    .readValue[List[GenericTestClass[Int]]](toplevelArrayJson)
```