### PR TITLE
upgrade sbt-osgi plugin, for JDK 15 support

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // For OSGI bundles
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
 
 // For making releases
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")


### PR DESCRIPTION
prevents this failure on JDK 15:

```
[jackson-module-scala] [error] java.util.ConcurrentModificationException
[jackson-module-scala] [error] 	at java.base/java.util.TreeMap.callMappingFunctionWithCheck(TreeMap.java:742)
[jackson-module-scala] [error] 	at java.base/java.util.TreeMap.computeIfAbsent(TreeMap.java:596)
[jackson-module-scala] [error] 	at aQute.bnd.osgi.Jar.putResource(Jar.java:288)
[jackson-module-scala] [error] 	at aQute.bnd.osgi.Jar.buildFromZip(Jar.java:216)
[jackson-module-scala] [error] 	at aQute.bnd.osgi.Jar.<init>(Jar.java:122)
[jackson-module-scala] [error] 	at aQute.bnd.osgi.Jar.<init>(Jar.java:148)
[jackson-module-scala] [error] 	at aQute.bnd.osgi.Analyzer.setClasspath(Analyzer.java:1597)
[jackson-module-scala] [error] 	at com.typesafe.sbt.osgi.Osgi$.bundleTask(Osgi.scala:57)
[jackson-module-scala] [error] 	at com.typesafe.sbt.osgi.SbtOsgi$.$anonfun$defaultOsgiSettings$1(SbtOsgi.scala:55)
[jackson-module-scala] [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
```

as seen at https://scala-ci.typesafe.com/job/scala-2.13.x-jdk15-integrate-community-build/1437/artifact/logs/jackson-module-scala-build.log