### PR TITLE
Add test for lazy val serialization

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -63,6 +63,12 @@ case class PrivateDefaultFields(
   @JsonProperty lastName: String = "Freeman"
 )
 
+case class LazyClass(data: String) {
+  lazy val lazyString: String = data
+  @JsonIgnore
+  lazy val lazyIgnoredString: String = data
+}
+
 @RunWith(classOf[JUnitRunner])
 class CaseClassSerializerTest extends SerializerTest {
 
@@ -195,5 +201,10 @@ class CaseClassSerializerTest extends SerializerTest {
     }
     val foo = new Foo(java.util.Arrays.asList("foo", "bar"))
     serialize(foo) should equal ("""{"strings":["foo","bar"]}""")
+  }
+
+  it should "exclude bitmap$0 field from serialization" in {
+    val lazyInstance = LazyClass("test")
+    serialize(lazyInstance) should equal ("""{"data":"test","lazyString":"test"}""")
   }
 }


### PR DESCRIPTION
As discussed in #113 we need to exclude `bitmap$0` from serialised value (I've reproduced it in 2.9.10 / 2.10.5 / 2.11.x / 2.12.0)

however turns out I was using modified mapper with hacky settings:
```scala
mapper.setVisibility(PropertyAccessor.CREATOR, Visibility.NONE)
mapper.setVisibility(PropertyAccessor.SETTER, Visibility.NONE)
mapper.setVisibility(PropertyAccessor.GETTER, Visibility.NONE)
mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
```

I think we can close #113 since it's not longer the case