### PR TITLE
Support for registering reference types (when they can't be inferred)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,8 @@ Compile / resourceGenerators += Def.task {
     Seq(file)
 }.taskValue
 
+Test / parallelExecution := false
+
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "mimaReportBinaryIssues")))
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
@@ -37,10 +37,6 @@ import scala.reflect.NameTransformer
 
 object BeanIntrospector {
 
-  private case class FieldKey(clazz: Class[_], fieldName: String)
-
-  private val overrideMap = scala.collection.mutable.Map[FieldKey, Class[_]]()
-
   def apply[T <: AnyRef](cls: Class[_]) = {
 
     /**
@@ -244,20 +240,6 @@ object BeanIntrospector {
     }
 
     BeanDescriptor(cls, fields ++ methods ++ lazyValMethods)
-  }
-
-  /**
-   * jackson-module-scala does not always properly handle deserialization of Options or Collections wrapping
-   * Scala primitives (eg Int, Long, Boolean). There are general issues with serializing and deserializing
-   * Scala 2 Enumerations. These issues can be worked around by adding Jackson annotations on the affected fields.
-   * This function is designed to be used when it is not possible to apply Jackson annotations.
-   *
-   * @param clazz
-   * @param fieldName
-   * @param referencedType
-   */
-  def registerReferencedType(clazz: Class[_], fieldName: String, referencedType: Class[_]): Unit = {
-    overrideMap.update(FieldKey(clazz, fieldName), referencedType)
   }
 
   private def getCtorParams(ctor: Constructor[_]): Seq[String] = {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/BeanIntrospector.scala
@@ -37,10 +37,9 @@ import scala.reflect.NameTransformer
 
 object BeanIntrospector {
 
-  private def getCtorParams(ctor: Constructor[_]): Seq[String] = {
-    val names = JavaParameterIntrospector.getCtorParamNames(ctor)
-    names.map(NameTransformer.decode)
-  }
+  private case class FieldKey(clazz: Class[_], fieldName: String)
+
+  private val overrideMap = scala.collection.mutable.Map[FieldKey, Class[_]]()
 
   def apply[T <: AnyRef](cls: Class[_]) = {
 
@@ -245,5 +244,24 @@ object BeanIntrospector {
     }
 
     BeanDescriptor(cls, fields ++ methods ++ lazyValMethods)
+  }
+
+  /**
+   * jackson-module-scala does not always properly handle deserialization of Options or Collections wrapping
+   * Scala primitives (eg Int, Long, Boolean). There are general issues with serializing and deserializing
+   * Scala 2 Enumerations. These issues can be worked around by adding Jackson annotations on the affected fields.
+   * This function is designed to be used when it is not possible to apply Jackson annotations.
+   *
+   * @param clazz
+   * @param fieldName
+   * @param referencedType
+   */
+  def registerReferencedType(clazz: Class[_], fieldName: String, referencedType: Class[_]): Unit = {
+    overrideMap.update(FieldKey(clazz, fieldName), referencedType)
+  }
+
+  private def getCtorParams(ctor: Constructor[_]): Seq[String] = {
+    val names = JavaParameterIntrospector.getCtorParamNames(ctor)
+    names.map(NameTransformer.decode)
   }
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -281,12 +281,11 @@ private case class WrappedCreatorProperty(creatorProperty: CreatorProperty, refC
   extends CreatorProperty(creatorProperty, creatorProperty.getFullName) {
 
   override def getType: JavaType = {
-    val result = super.getType match {
+    super.getType match {
       case rt: ReferenceType => ReferenceType.upgradeFrom(rt, SimpleType.constructUnsafe(refClass))
       case ct: CollectionLikeType => CollectionLikeType.upgradeFrom(ct, SimpleType.constructUnsafe(refClass))
       case mt: MapLikeType => MapLikeType.upgradeFrom(mt, mt.getKeyType, SimpleType.constructUnsafe(refClass))
       case other => other
     }
-    result
   }
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.scala.introspect
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.`type`.{ClassKey, CollectionLikeType, ReferenceType, SimpleType}
+import com.fasterxml.jackson.databind.`type`.{ClassKey, CollectionLikeType, MapLikeType, ReferenceType, SimpleType}
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.deser._
@@ -281,10 +281,12 @@ private case class WrappedCreatorProperty(creatorProperty: CreatorProperty, refC
   extends CreatorProperty(creatorProperty, creatorProperty.getFullName) {
 
   override def getType: JavaType = {
-    super.getType match {
+    val result = super.getType match {
       case rt: ReferenceType => ReferenceType.upgradeFrom(rt, SimpleType.constructUnsafe(refClass))
       case ct: CollectionLikeType => CollectionLikeType.upgradeFrom(ct, SimpleType.constructUnsafe(refClass))
+      case mt: MapLikeType => MapLikeType.upgradeFrom(mt, mt.getKeyType, SimpleType.constructUnsafe(refClass))
       case other => other
     }
+    result
   }
 }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.scala.introspect
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.`type`.{ClassKey, ReferenceType, SimpleType}
+import com.fasterxml.jackson.databind.`type`.{ClassKey, CollectionLikeType, CollectionType, ReferenceType, SimpleType}
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.deser._
@@ -283,6 +283,7 @@ private case class WrappedCreatorProperty(creatorProperty: CreatorProperty, refC
   override def getType: JavaType = {
     super.getType match {
       case rt: ReferenceType => ReferenceType.upgradeFrom(rt, SimpleType.constructUnsafe(refClass))
+      case ct: CollectionLikeType => CollectionLikeType.upgradeFrom(ct, SimpleType.constructUnsafe(refClass))
       case other => other
     }
   }

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.module.scala.introspect
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.databind.`type`.{ClassKey, CollectionLikeType, CollectionType, ReferenceType, SimpleType}
+import com.fasterxml.jackson.databind.`type`.{ClassKey, CollectionLikeType, ReferenceType, SimpleType}
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.deser._

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -2,17 +2,17 @@ package com.fasterxml.jackson.module.scala.introspect
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.databind.`type`.ClassKey
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.cfg.MapperConfig
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.deser._
 import com.fasterxml.jackson.databind.introspect._
-import com.fasterxml.jackson.databind.util.{AccessPattern, LRUMap, LookupCache}
-import com.fasterxml.jackson.databind.{BeanDescription, DeserializationConfig, DeserializationContext, MapperFeature}
+import com.fasterxml.jackson.databind.util.{AccessPattern, Converter, LRUMap, LookupCache}
+import com.fasterxml.jackson.databind.{BeanDescription, DeserializationConfig, DeserializationContext, JsonDeserializer, KeyDeserializer, MapperFeature}
 import com.fasterxml.jackson.module.scala.JacksonModule
 import com.fasterxml.jackson.module.scala.util.Implicits._
 
 import java.lang.annotation.Annotation
-import scala.collection.JavaConverters._
 
 object ScalaAnnotationIntrospector extends NopAnnotationIntrospector with ValueInstantiators {
   private [this] var _descriptorCache: LookupCache[ClassKey, BeanDescriptor] =
@@ -140,20 +140,23 @@ object ScalaAnnotationIntrospector extends NopAnnotationIntrospector with ValueI
               // Locate the constructor param that matches it
               descriptor.properties.find(_.param.exists(_.index == creator.getCreatorIndex)) match {
                 case Some(pd) => {
-                  println(s">>>>> override ${pd.name} ${overrides.get(pd.name)}")
+                  val mappedCreator = overrides.get(pd.name) match {
+                    case Some(refClass) => WrappedCreatorProperty(creator, refClass)
+                    case _ => creator
+                  }
                   if (applyDefaultValues) {
                     pd match {
                       case PropertyDescriptor(_, Some(ConstructorParameter(_, _, Some(defaultValue))), _, _, _, _, _) => {
-                        creator.withNullProvider(new NullValueProvider {
+                        mappedCreator.withNullProvider(new NullValueProvider {
                           override def getNullValue(ctxt: DeserializationContext): AnyRef = defaultValue()
 
                           override def getNullAccessPattern: AccessPattern = AccessPattern.DYNAMIC
                         })
                       }
-                      case _ => creator
+                      case _ => mappedCreator
                     }
                   } else {
-                    creator
+                    mappedCreator
                   }
                 }
                 case _ => creator
@@ -249,4 +252,31 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
   this += { _.appendAnnotationIntrospector(JavaAnnotationIntrospector) }
   this += { _.appendAnnotationIntrospector(ScalaAnnotationIntrospector) }
   this += { _.addValueInstantiators(ScalaAnnotationIntrospector) }
+}
+
+private case class WrappedCreatorProperty(creatorProperty: CreatorProperty, refClass: Class[_])
+  extends CreatorProperty(creatorProperty, creatorProperty.getFullName) {
+
+  override def getAnnotation[A <: Annotation](acls: Class[A]): A = {
+    val result = Option(super.getAnnotation(acls)) match {
+      case None if acls.isAssignableFrom(classOf[JsonDeserialize]) => Some(getInstanceOfContentAsAnnotation())
+      case result => result
+    }
+    result.orNull.asInstanceOf[A]
+  }
+
+  private def getInstanceOfContentAsAnnotation(): JsonDeserialize = {
+    new JsonDeserialize() {
+      override def contentAs: Class[_] = refClass
+      override def annotationType: Class[JsonDeserialize] = classOf[JsonDeserialize]
+      override def as(): Class[_] = classOf[Void]
+      override def keyAs(): Class[_] = classOf[Void]
+      override def builder(): Class[_] = classOf[Void]
+      override def contentConverter(): Class[_ <: Converter[_, _]] = classOf[Converter.None]
+      override def converter(): Class[_ <: Converter[_, _]] = classOf[Converter.None]
+      override def using(): Class[_ <: JsonDeserializer[_]] = classOf[JsonDeserializer.None]
+      override def contentUsing(): Class[_ <: JsonDeserializer[_]] = classOf[JsonDeserializer.None]
+      override def keyUsing(): Class[_ <: KeyDeserializer] = classOf[KeyDeserializer.None]
+    }
+  }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
@@ -39,10 +39,10 @@ class MapWithNumberValueDeserializerTest extends DeserializerTest with BeforeAnd
   }
 
   it should "deserialize MapLong" in {
-    ScalaAnnotationIntrospector.registerReferencedType(classOf[MapLong], "longs", classOf[Long])
+    ScalaAnnotationIntrospector.registerReferencedValueType(classOf[MapLong], "longs", classOf[Long])
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapLong])
     v1 shouldBe MapLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
-    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedValueType
     //or use one of the equivalent classes in MapWithNumberDeserializerTest
     sumMapLong(v1.longs) shouldBe 456L
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
@@ -26,19 +26,19 @@ class MapWithNumberValueDeserializerTest extends DeserializerTest with BeforeAnd
     ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
   }
 
-  "JacksonModuleScala" should "support AnnotatedMapLong" in {
+  "JacksonModuleScala" should "deserialize AnnotatedMapLong" in {
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[AnnotatedMapLong])
     v1 shouldBe AnnotatedMapLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
     sumMapLong(v1.longs) shouldBe 456L
   }
 
-  it should "support AnnotatedMapPrimitiveLong" in {
+  it should "deserialize AnnotatedMapPrimitiveLong" in {
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[AnnotatedMapPrimitiveLong])
     v1 shouldBe AnnotatedMapPrimitiveLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
     sumMapLong(v1.longs) shouldBe 456L
   }
 
-  it should "support MapLong" in {
+  it should "deserialize MapLong" in {
     ScalaAnnotationIntrospector.registerReferencedType(classOf[MapLong], "longs", classOf[Long])
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapLong])
     v1 shouldBe MapLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
@@ -47,13 +47,13 @@ class MapWithNumberValueDeserializerTest extends DeserializerTest with BeforeAnd
     sumMapLong(v1.longs) shouldBe 456L
   }
 
-  it should "support MapJavaLong" in {
+  it should "deserialize MapJavaLong" in {
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapJavaLong])
     v1 shouldBe MapJavaLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
     sumMapJavaLong(v1.longs) shouldBe 456L
   }
 
-  it should "support MapBigInt" in {
+  it should "deserialize MapBigInt" in {
     val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapBigInt])
     v1 shouldBe MapBigInt(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
     sumMapBigInt(v1.longs) shouldBe 456L

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/MapWithNumberValueDeserializerTest.scala
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector
+import org.scalatest.BeforeAndAfterEach
+
+object MapWithNumberValueDeserializerTest {
+  case class AnnotatedMapLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) longs: Map[String, Long])
+  case class AnnotatedMapPrimitiveLong(@JsonDeserialize(contentAs = classOf[Long]) longs: Map[String, Long])
+  case class MapLong(longs: Map[String, Long])
+  case class MapJavaLong(longs: Map[String, java.lang.Long])
+  case class MapBigInt(longs: Map[String, BigInt])
+}
+
+class MapWithNumberValueDeserializerTest extends DeserializerTest with BeforeAndAfterEach {
+  lazy val module: DefaultScalaModule.type = DefaultScalaModule
+  import MapWithNumberValueDeserializerTest._
+
+  private def sumMapLong(m: Map[String, Long]): Long = m.values.sum
+  private def sumMapJavaLong(m: Map[String, java.lang.Long]): Long = m.values.map(_.toLong).sum
+  private def sumMapBigInt(m: Map[String, BigInt]): Long = m.values.sum.toLong
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
+  }
+
+  "JacksonModuleScala" should "support AnnotatedMapLong" in {
+    val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[AnnotatedMapLong])
+    v1 shouldBe AnnotatedMapLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
+    sumMapLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support AnnotatedMapPrimitiveLong" in {
+    val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[AnnotatedMapPrimitiveLong])
+    v1 shouldBe AnnotatedMapPrimitiveLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
+    sumMapLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support MapLong" in {
+    ScalaAnnotationIntrospector.registerReferencedType(classOf[MapLong], "longs", classOf[Long])
+    val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapLong])
+    v1 shouldBe MapLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //or use one of the equivalent classes in MapWithNumberDeserializerTest
+    sumMapLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support MapJavaLong" in {
+    val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapJavaLong])
+    v1 shouldBe MapJavaLong(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
+    sumMapJavaLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support MapBigInt" in {
+    val v1 = deserialize("""{"longs":{"151":151,"152":152,"153":153}}""", classOf[MapBigInt])
+    v1 shouldBe MapBigInt(Map("151" -> 151L, "152" -> 152L, "153" -> 153L))
+    sumMapBigInt(v1.longs) shouldBe 456L
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
@@ -1,0 +1,57 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector
+import org.scalatest.BeforeAndAfterEach
+
+object OptionWithBooleanDeserializerTest {
+  case class AnnotatedOptionBoolean(@JsonDeserialize(contentAs = classOf[java.lang.Boolean]) valueBoolean: Option[Boolean])
+  case class AnnotatedOptionPrimitiveBoolean(@JsonDeserialize(contentAs = classOf[Boolean]) valueBoolean: Option[Boolean])
+  case class OptionBoolean(valueBoolean: Option[Boolean])
+  case class OptionJavaBoolean(valueBoolean: Option[java.lang.Boolean])
+}
+
+class OptionWithBooleanDeserializerTest extends DeserializerTest with BeforeAndAfterEach {
+  lazy val module: DefaultScalaModule.type = DefaultScalaModule
+  import OptionWithBooleanDeserializerTest._
+
+  private def useOptionBoolean(v: Option[Boolean]): String = v.map(_.toString).getOrElse("null")
+  private def useOptionJavaBoolean(v: Option[java.lang.Boolean]): String = v.map(_.toString).getOrElse("null")
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
+  }
+
+  "JacksonModuleScala" should "support AnnotatedOptionBoolean" in {
+    val v1 = deserialize("""{"valueBoolean":false}""", classOf[AnnotatedOptionBoolean])
+    v1 shouldBe AnnotatedOptionBoolean(Some(false))
+    v1.valueBoolean.get shouldBe false
+    useOptionBoolean(v1.valueBoolean) shouldBe "false"
+  }
+
+  it should "support AnnotatedOptionPrimitiveBoolean" in {
+    val v1 = deserialize("""{"valueBoolean":false}""", classOf[AnnotatedOptionPrimitiveBoolean])
+    v1 shouldBe AnnotatedOptionPrimitiveBoolean(Some(false))
+    v1.valueBoolean.get shouldBe false
+    useOptionBoolean(v1.valueBoolean) shouldBe "false"
+  }
+
+  it should "support OptionBoolean" in {
+    ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionBoolean], "valueBoolean", classOf[Boolean])
+    val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
+    v1 shouldBe OptionBoolean(Some(false))
+    v1.valueBoolean.get shouldBe false
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //or use one of the equivalent classes in OptionWithBooleanDeserializerTest
+    useOptionBoolean(v1.valueBoolean) shouldBe "false"
+  }
+
+  it should "support OptionJavaBoolean" in {
+    val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionJavaBoolean])
+    v1 shouldBe OptionJavaBoolean(Some(false))
+    v1.valueBoolean.get shouldBe false
+    useOptionJavaBoolean(v1.valueBoolean) shouldBe "false"
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
@@ -38,13 +38,18 @@ class OptionWithBooleanDeserializerTest extends DeserializerTest with BeforeAndA
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "support OptionBoolean" in {
+  it should "support OptionBoolean (without registerReferencedType)" in {
+    val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
+    v1 shouldBe OptionBoolean(Some(false))
+    v1.valueBoolean.get shouldBe false
+    useOptionBoolean(v1.valueBoolean) shouldBe "false"
+  }
+
+  it should "support OptionBoolean (with registerReferencedType)" in {
     ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionBoolean], "valueBoolean", classOf[Boolean])
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
     v1 shouldBe OptionBoolean(Some(false))
     v1.valueBoolean.get shouldBe false
-    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
-    //or use one of the equivalent classes in OptionWithBooleanDeserializerTest
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
@@ -38,15 +38,15 @@ class OptionWithBooleanDeserializerTest extends DeserializerTest with BeforeAndA
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "deserialize OptionBoolean (without registerReferencedType)" in {
+  it should "deserialize OptionBoolean (without registerReferencedValueType)" in {
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
     v1 shouldBe OptionBoolean(Some(false))
     v1.valueBoolean.get shouldBe false
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "deserialize OptionBoolean (with registerReferencedType)" in {
-    ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionBoolean], "valueBoolean", classOf[Boolean])
+  it should "deserialize OptionBoolean (with registerReferencedValueType)" in {
+    ScalaAnnotationIntrospector.registerReferencedValueType(classOf[OptionBoolean], "valueBoolean", classOf[Boolean])
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
     v1 shouldBe OptionBoolean(Some(false))
     v1.valueBoolean.get shouldBe false

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithBooleanDeserializerTest.scala
@@ -24,28 +24,28 @@ class OptionWithBooleanDeserializerTest extends DeserializerTest with BeforeAndA
     ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
   }
 
-  "JacksonModuleScala" should "support AnnotatedOptionBoolean" in {
+  "JacksonModuleScala" should "deserialize AnnotatedOptionBoolean" in {
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[AnnotatedOptionBoolean])
     v1 shouldBe AnnotatedOptionBoolean(Some(false))
     v1.valueBoolean.get shouldBe false
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "support AnnotatedOptionPrimitiveBoolean" in {
+  it should "deserialize AnnotatedOptionPrimitiveBoolean" in {
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[AnnotatedOptionPrimitiveBoolean])
     v1 shouldBe AnnotatedOptionPrimitiveBoolean(Some(false))
     v1.valueBoolean.get shouldBe false
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "support OptionBoolean (without registerReferencedType)" in {
+  it should "deserialize OptionBoolean (without registerReferencedType)" in {
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
     v1 shouldBe OptionBoolean(Some(false))
     v1.valueBoolean.get shouldBe false
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "support OptionBoolean (with registerReferencedType)" in {
+  it should "deserialize OptionBoolean (with registerReferencedType)" in {
     ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionBoolean], "valueBoolean", classOf[Boolean])
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionBoolean])
     v1 shouldBe OptionBoolean(Some(false))
@@ -53,7 +53,7 @@ class OptionWithBooleanDeserializerTest extends DeserializerTest with BeforeAndA
     useOptionBoolean(v1.valueBoolean) shouldBe "false"
   }
 
-  it should "support OptionJavaBoolean" in {
+  it should "deserialize OptionJavaBoolean" in {
     val v1 = deserialize("""{"valueBoolean":false}""", classOf[OptionJavaBoolean])
     v1 shouldBe OptionJavaBoolean(Some(false))
     v1.valueBoolean.get shouldBe false

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
@@ -41,11 +41,11 @@ class OptionWithNumberDeserializerTest extends DeserializerTest with BeforeAndAf
   }
 
   it should "deserialize OptionLong" in {
-    ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])
+    ScalaAnnotationIntrospector.registerReferencedValueType(classOf[OptionLong], "valueLong", classOf[Long])
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionLong])
     v1 shouldBe OptionLong(Some(151L))
     v1.valueLong.get shouldBe 151L
-    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedValueType
     //or use one of the equivalent classes in OptionWithNumberDeserializerTest
     useOptionLong(v1.valueLong) shouldBe 302L
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.introspect.BeanIntrospector
 
 object OptionWithNumberDeserializerTest {
   case class AnnotatedOptionLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) valueLong: Option[Long])
@@ -34,12 +35,13 @@ class OptionWithNumberDeserializerTest extends DeserializerTest {
   }
 
   it should "support OptionLong" in {
+    BeanIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionLong])
     v1 shouldBe OptionLong(Some(151L))
     v1.valueLong.get shouldBe 151L
-    //next assert fails due to unboxing issue -- without the @JsonDeserialize to help, jackson will
-    //erroneously create an Option[Int] instead of Option[Long] leading to a class cast exception
-    //useOptionLong(v1.valueLong) shouldBe 302L
+    //this will next call will fail with a Scala unboxing exception unless you BeanIntrospector.registerReferencedType
+    //or use one of the equivalent classes in OptionWithNumberDeserializerTest
+    useOptionLong(v1.valueLong) shouldBe 302L
   }
 
   it should "support OptionJavaLong" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
@@ -2,7 +2,8 @@ package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.introspect.BeanIntrospector
+import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector
+import org.scalatest.BeforeAndAfterEach
 
 object OptionWithNumberDeserializerTest {
   case class AnnotatedOptionLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) valueLong: Option[Long])
@@ -12,13 +13,18 @@ object OptionWithNumberDeserializerTest {
   case class OptionBigInt(value: Option[BigInt])
 }
 
-class OptionWithNumberDeserializerTest extends DeserializerTest {
+class OptionWithNumberDeserializerTest extends DeserializerTest with BeforeAndAfterEach {
   lazy val module: DefaultScalaModule.type = DefaultScalaModule
   import OptionWithNumberDeserializerTest._
 
   private def useOptionLong(v: Option[Long]): Long = v.map(_ * 2).getOrElse(0L)
   private def useOptionJavaLong(v: Option[java.lang.Long]): Long = v.map(_ * 2).getOrElse(0L)
   private def useOptionBigInt(v: Option[BigInt]): Long = v.map(_ * 2).map(_.toLong).getOrElse(0L)
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
+  }
 
   "JacksonModuleScala" should "support AnnotatedOptionLong" in {
     val v1 = deserialize("""{"valueLong":151}""", classOf[AnnotatedOptionLong])
@@ -35,7 +41,7 @@ class OptionWithNumberDeserializerTest extends DeserializerTest {
   }
 
   it should "support OptionLong" in {
-    BeanIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])
+    ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionLong])
     v1 shouldBe OptionLong(Some(151L))
     v1.valueLong.get shouldBe 151L

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
@@ -26,21 +26,21 @@ class OptionWithNumberDeserializerTest extends DeserializerTest with BeforeAndAf
     ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
   }
 
-  "JacksonModuleScala" should "support AnnotatedOptionLong" in {
+  "JacksonModuleScala" should "deserialize AnnotatedOptionLong" in {
     val v1 = deserialize("""{"valueLong":151}""", classOf[AnnotatedOptionLong])
     v1 shouldBe AnnotatedOptionLong(Some(151L))
     v1.valueLong.get shouldBe 151L
     useOptionLong(v1.valueLong) shouldBe 302L
   }
 
-  it should "support AnnotatedOptionPrimitiveLong" in {
+  it should "deserialize AnnotatedOptionPrimitiveLong" in {
     val v1 = deserialize("""{"valueLong":151}""", classOf[AnnotatedOptionPrimitiveLong])
     v1 shouldBe AnnotatedOptionPrimitiveLong(Some(151L))
     v1.valueLong.get shouldBe 151L
     useOptionLong(v1.valueLong) shouldBe 302L
   }
 
-  it should "support OptionLong" in {
+  it should "deserialize OptionLong" in {
     ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionLong])
     v1 shouldBe OptionLong(Some(151L))
@@ -50,14 +50,14 @@ class OptionWithNumberDeserializerTest extends DeserializerTest with BeforeAndAf
     useOptionLong(v1.valueLong) shouldBe 302L
   }
 
-  it should "support OptionJavaLong" in {
+  it should "deserialize OptionJavaLong" in {
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionJavaLong])
     v1 shouldBe OptionJavaLong(Some(151L))
     v1.valueLong.get shouldBe 151L
     useOptionJavaLong(v1.valueLong) shouldBe 302L
   }
 
-  it should "support OptionBigInt" in {
+  it should "deserialize OptionBigInt" in {
     val v1 = deserialize("""{"value":151}""", classOf[OptionBigInt])
     v1 shouldBe OptionBigInt(Some(BigInt(151L)))
     v1.value.get shouldBe 151L

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/OptionWithNumberDeserializerTest.scala
@@ -45,7 +45,7 @@ class OptionWithNumberDeserializerTest extends DeserializerTest with BeforeAndAf
     val v1 = deserialize("""{"valueLong":151}""", classOf[OptionLong])
     v1 shouldBe OptionLong(Some(151L))
     v1.valueLong.get shouldBe 151L
-    //this will next call will fail with a Scala unboxing exception unless you BeanIntrospector.registerReferencedType
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
     //or use one of the equivalent classes in OptionWithNumberDeserializerTest
     useOptionLong(v1.valueLong) shouldBe 302L
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
@@ -39,10 +39,10 @@ class SeqWithNumberDeserializerTest extends DeserializerTest with BeforeAndAfter
   }
 
   it should "deserialize SeqLong" in {
-    ScalaAnnotationIntrospector.registerReferencedType(classOf[SeqLong], "longs", classOf[Long])
+    ScalaAnnotationIntrospector.registerReferencedValueType(classOf[SeqLong], "longs", classOf[Long])
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqLong])
     v1 shouldBe SeqLong(Seq(151L, 152L, 153L))
-    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedValueType
     //or use one of the equivalent classes in SeqWithNumberDeserializerTest
     sumSeqLong(v1.longs) shouldBe 456L
   }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospector
+import org.scalatest.BeforeAndAfterEach
+
+object SeqWithNumberDeserializerTest {
+  case class AnnotatedSeqLong(@JsonDeserialize(contentAs = classOf[java.lang.Long]) longs: Seq[Long])
+  case class AnnotatedSeqPrimitiveLong(@JsonDeserialize(contentAs = classOf[Long]) longs: Seq[Long])
+  case class SeqLong(longs: Seq[Long])
+  case class SeqJavaLong(longs: Seq[java.lang.Long])
+  case class SeqBigInt(longs: Seq[BigInt])
+}
+
+class SeqWithNumberDeserializerTest extends DeserializerTest with BeforeAndAfterEach {
+  lazy val module: DefaultScalaModule.type = DefaultScalaModule
+  import SeqWithNumberDeserializerTest._
+
+  private def sumSeqLong(v: Seq[Long]): Long = v.sum
+  private def sumSeqJavaLong(v: Seq[java.lang.Long]): Long = v.map(_.toLong).sum
+  private def sumSeqBigInt(v: Seq[BigInt]): Long = v.sum.toLong
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
+  }
+
+  "JacksonModuleScala" should "support AnnotatedSeqLong" in {
+    val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[AnnotatedSeqLong])
+    v1 shouldBe AnnotatedSeqLong(Seq(151L, 152L, 153L))
+    sumSeqLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support AnnotatedSeqPrimitiveLong" in {
+    val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[AnnotatedSeqPrimitiveLong])
+    v1 shouldBe AnnotatedSeqPrimitiveLong(Seq(151L, 152L, 153L))
+    sumSeqLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support SeqLong" in {
+    ScalaAnnotationIntrospector.registerReferencedType(classOf[SeqLong], "longs", classOf[Long])
+    val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqLong])
+    v1 shouldBe SeqLong(Seq(151L, 152L, 153L))
+    //this will next call will fail with a Scala unboxing exception unless you ScalaAnnotationIntrospector.registerReferencedType
+    //or use one of the equivalent classes in SeqWithNumberDeserializerTest
+    sumSeqLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support SeqJavaLong" in {
+    val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqJavaLong])
+    v1 shouldBe SeqJavaLong(Seq(151L, 152L, 153L))
+    sumSeqJavaLong(v1.longs) shouldBe 456L
+  }
+
+  it should "support SeqBigInt" in {
+    val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqBigInt])
+    v1 shouldBe SeqBigInt(Seq(151L, 152L, 153L))
+    sumSeqBigInt(v1.longs) shouldBe 456L
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/SeqWithNumberDeserializerTest.scala
@@ -26,19 +26,19 @@ class SeqWithNumberDeserializerTest extends DeserializerTest with BeforeAndAfter
     ScalaAnnotationIntrospector.clearRegisteredReferencedTypes()
   }
 
-  "JacksonModuleScala" should "support AnnotatedSeqLong" in {
+  "JacksonModuleScala" should "deserialize AnnotatedSeqLong" in {
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[AnnotatedSeqLong])
     v1 shouldBe AnnotatedSeqLong(Seq(151L, 152L, 153L))
     sumSeqLong(v1.longs) shouldBe 456L
   }
 
-  it should "support AnnotatedSeqPrimitiveLong" in {
+  it should "deserialize AnnotatedSeqPrimitiveLong" in {
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[AnnotatedSeqPrimitiveLong])
     v1 shouldBe AnnotatedSeqPrimitiveLong(Seq(151L, 152L, 153L))
     sumSeqLong(v1.longs) shouldBe 456L
   }
 
-  it should "support SeqLong" in {
+  it should "deserialize SeqLong" in {
     ScalaAnnotationIntrospector.registerReferencedType(classOf[SeqLong], "longs", classOf[Long])
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqLong])
     v1 shouldBe SeqLong(Seq(151L, 152L, 153L))
@@ -47,13 +47,13 @@ class SeqWithNumberDeserializerTest extends DeserializerTest with BeforeAndAfter
     sumSeqLong(v1.longs) shouldBe 456L
   }
 
-  it should "support SeqJavaLong" in {
+  it should "deserialize SeqJavaLong" in {
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqJavaLong])
     v1 shouldBe SeqJavaLong(Seq(151L, 152L, 153L))
     sumSeqJavaLong(v1.longs) shouldBe 456L
   }
 
-  it should "support SeqBigInt" in {
+  it should "deserialize SeqBigInt" in {
     val v1 = deserialize("""{"longs":[151,152,153]}""", classOf[SeqBigInt])
     v1 shouldBe SeqBigInt(Seq(151L, 152L, 153L))
     sumSeqBigInt(v1.longs) shouldBe 456L


### PR DESCRIPTION
* current code can't handle deserialization for `case class OptionLong(valueLong: Option[Long])`
  * type erasure of scala.Long (an alias for the java long primitive) causes this
* You can use java.lang.Long, scala.BigInt or other reference types with no issue
* You can use Jackson JsonDeserialize annotation to annotate the valueLong field
* This new support is experimental and you should prefer the existing workarounds 
* `ScalaAnnotationIntrospector.registerReferencedType(clazz: Class[_], fieldName: String, referencedType: Class[_])` is the main API for this change
  * in the `OptionLong` example: `ScalaAnnotationIntrospector.registerReferencedType(classOf[OptionLong], "valueLong", classOf[Long])`