### PR TITLE
Ignore generated methods for default arguments

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -47,7 +47,7 @@ object ScalaAnnotationIntrospector extends NopAnnotationIntrospector with ValueI
   override def hasIgnoreMarker(m: AnnotatedMember): Boolean = {
     val name = m.getName
     //special cases to prevent shadow fields associated with lazy vals being serialized
-    name == "0bitmap$1" || name.endsWith("$lzy1") || super.hasIgnoreMarker(m)
+    name == "0bitmap$1" || name.endsWith("$lzy1") || name.contains("$default$") || super.hasIgnoreMarker(m)
   }
 
   override def hasCreatorAnnotation(a: Annotated): Boolean = {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorTest.scala
@@ -31,6 +31,9 @@ object ScalaAnnotationIntrospectorTest {
     @JsonProperty def getValue: Int = value
     @JsonProperty def setValue(value: Int): Unit = { this.value = value }
   }
+  class GeneratedDefaultArgumentClass {
+    def getValue(value: String = "default"): String = value
+  }
 
   case class CaseClassWithDefault(a: String = "defaultParam", b: Option[String] = Some("optionDefault"), c: Option[String])
 
@@ -239,6 +242,12 @@ class ScalaAnnotationIntrospectorTest extends FixtureAnyFlatSpec with Matchers {
 
     cache.size shouldBe >=(1)
     cache.get(new ClassKey(classOf[CaseClassWithDefault])) should not be(null)
+  }
+
+  it should "ignore a generated default argument method" in { mapper =>
+    val bean = new GeneratedDefaultArgumentClass
+    val allProps = getProps(mapper, bean)
+    allProps shouldBe empty
   }
 
   private def getProps(mapper: ObjectMapper, bean: AnyRef) = {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -198,4 +198,13 @@ class CaseClassSerializerTest extends SerializerTest {
   it should "serialize ClassWithOnlyUnitField" in {
     serialize(ClassWithOnlyUnitField(())) shouldEqual """{}"""
   }
+
+  it should "not find properties for default arguments" in {
+    case class GeneratedDefaultArgumentClass() {
+      def getValue(value: String = "default"): String = value
+    }
+
+    serialize(GeneratedDefaultArgumentClass()) shouldEqual "{}"
+  }
+
 }


### PR DESCRIPTION
When a method with default arguments has a name that matches JavaBeans property conventions, the generated method that computes the default argument expression is detected as a property.