### PR TITLE
test StreamReadCapability.DUPLICATE_PROPERTIES (IntMap/LongMap)

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerResolver.scala
@@ -76,8 +76,18 @@ private[deser] object IntMapDeserializerResolver extends Deserializers.Base {
 
     override def put(k: Object, v: Object): Object = {
       k match {
-        case n: Number => baseMap += (n.intValue() -> v)
-        case s: String => baseMap += (s.toInt -> v)
+        case n: Number => {
+          val i = n.intValue()
+          val oldValue = baseMap.get(i)
+          baseMap += (i -> v)
+          oldValue.orNull
+        }
+        case s: String => {
+          val i = s.toInt
+          val oldValue = baseMap.get(i)
+          baseMap += (i -> v)
+          oldValue.orNull
+        }
         case _ => {
           val typeName = Option(k) match {
             case Some(n) => n.getClass.getName
@@ -86,7 +96,6 @@ private[deser] object IntMapDeserializerResolver extends Deserializers.Base {
           throw new IllegalArgumentException(s"IntMap does not support keys of type $typeName")
         }
       }
-      v
     }
 
     // Used by the deserializer when using readerForUpdating

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/LongMapDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/LongMapDeserializerResolver.scala
@@ -118,8 +118,18 @@ private[deser] object LongMapDeserializerResolver extends Deserializers.Base {
 
     override def put(k: Object, v: Object): Object = {
       k match {
-        case n: Number => baseMap += (n.longValue() -> v)
-        case s: String => baseMap += (s.toLong -> v)
+        case n: Number => {
+          val l = n.longValue()
+          val oldValue = baseMap.get(l)
+          baseMap += (l -> v)
+          oldValue.orNull
+        }
+        case s: String => {
+          val l = s.toLong
+          val oldValue = baseMap.get(l)
+          baseMap += (l -> v)
+          oldValue.orNull
+        }
         case _ => {
           val typeName = Option(k) match {
             case Some(n) => n.getClass.getName
@@ -128,7 +138,6 @@ private[deser] object LongMapDeserializerResolver extends Deserializers.Base {
           throw new IllegalArgumentException(s"LongMap does not support keys of type $typeName")
         }
       }
-      v
     }
 
     // Used by the deserializer when using readerForUpdating
@@ -150,8 +159,18 @@ private[deser] object LongMapDeserializerResolver extends Deserializers.Base {
 
     override def put(k: Object, v: Object): Object = {
       k match {
-        case n: Number => baseMap += (n.longValue() -> v)
-        case s: String => baseMap += (s.toLong -> v)
+        case n: Number => {
+          val l = n.longValue()
+          val oldValue = baseMap.get(l)
+          baseMap += (l -> v)
+          oldValue.orNull
+        }
+        case s: String => {
+          val l = s.toLong
+          val oldValue = baseMap.get(l)
+          baseMap += (l -> v)
+          oldValue.orNull
+        }
         case _ => {
           val typeName = Option(k) match {
             case Some(n) => n.getClass.getName
@@ -160,7 +179,6 @@ private[deser] object LongMapDeserializerResolver extends Deserializers.Base {
           throw new IllegalArgumentException(s"LongMap does not support keys of type $typeName")
         }
       }
-      v
     }
 
     // Used by the deserializer when using readerForUpdating

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerTest.scala
@@ -1,7 +1,9 @@
 package com.fasterxml.jackson.module.scala.deser
 
+import com.fasterxml.jackson.core.{JsonParser, StreamReadCapability}
 import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import com.fasterxml.jackson.core.util.{JacksonFeatureSet, JsonParserDelegate}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.deser.IntMapDeserializerTest.{Event, IntMapWrapper}
 
 import java.util.UUID
@@ -86,5 +88,48 @@ class IntMapDeserializerTest extends DeserializerTest {
     read(0) shouldBe false
     read(1) shouldEqual "true"
     read(2) shouldEqual Map("id" -> event.id.toString, "description" -> event.description)
+  }
+
+  it should "deserialize IntMap (Object values, duplicate keys - default mode)" in {
+    val mapper = newMapper
+    val json = """{"1": 123, "2": 123, "2": 123.456}"""
+    val read = mapper.readValue(json, classOf[IntMap[Any]])
+    read(1) shouldEqual 123
+    read(2) shouldEqual 123.456
+  }
+
+  it should "deserialize IntMap (Object values, duplicate keys - optional mode)" in {
+    val mapper = newMapper
+    val json = """{"1": 123, "2": 123, "2": 123.456}"""
+    val parser = new WithDupsParser(mapper.createParser(json))
+    val read = try {
+      mapper.readValue(parser, classOf[IntMap[Any]])
+    } finally {
+      parser.close()
+    }
+    read(1) shouldEqual 123
+    val expected = new java.util.ArrayList[Object]()
+    expected.add(java.lang.Integer.valueOf(123))
+    expected.add(java.lang.Double.valueOf(123.456))
+    read(2) shouldEqual expected
+  }
+
+  it should "deserialize IntMap (Double values, duplicate key mode is ignored)" in {
+    val mapper = newMapper
+    val json = """{"1": "123", "2": "123", "2": "123.456"}"""
+    val parser = new WithDupsParser(mapper.createParser(json))
+    val read = try {
+      mapper.readValue(parser, new TypeReference[IntMap[String]]{})
+    } finally {
+      parser.close()
+    }
+    read(1) shouldEqual "123"
+    read(2) shouldEqual "123.456"
+  }
+
+  class WithDupsParser(p: JsonParser) extends JsonParserDelegate(p) {
+    override def getReadCapabilities: JacksonFeatureSet[StreamReadCapability] = {
+      super.getReadCapabilities.`with`(StreamReadCapability.DUPLICATE_PROPERTIES)
+    }
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/IntMapDeserializerTest.scala
@@ -1,8 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.{JsonParser, StreamReadCapability}
 import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.core.util.{JacksonFeatureSet, JsonParserDelegate}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.deser.IntMapDeserializerTest.{Event, IntMapWrapper}
 
@@ -125,11 +123,5 @@ class IntMapDeserializerTest extends DeserializerTest {
     }
     read(1) shouldEqual "123"
     read(2) shouldEqual "123.456"
-  }
-
-  class WithDupsParser(p: JsonParser) extends JsonParserDelegate(p) {
-    override def getReadCapabilities: JacksonFeatureSet[StreamReadCapability] = {
-      super.getReadCapabilities.`with`(StreamReadCapability.DUPLICATE_PROPERTIES)
-    }
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/LongMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/LongMapDeserializerTest.scala
@@ -2,7 +2,9 @@ package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.deser.IntMapDeserializerTest.Event
 
+import java.util.UUID
 import scala.collection.{immutable, mutable}
 
 class LongMapDeserializerTest extends DeserializerTest {
@@ -79,5 +81,53 @@ class LongMapDeserializerTest extends DeserializerTest {
     read shouldEqual map
     read(0) shouldBe false
     read(402) shouldBe true
+  }
+
+  it should "deserialize IntMap (Object values)" in {
+    val event = Event(UUID.randomUUID(), "event1")
+    val map = mutable.LongMap(0L -> false, 1L -> "true", 2L -> event)
+    val mapper = newMapper
+    val json = mapper.writeValueAsString(map)
+    val read = mapper.readValue(json, classOf[mutable.LongMap[Any]])
+    read(0) shouldBe false
+    read(1) shouldEqual "true"
+    read(2) shouldEqual Map("id" -> event.id.toString, "description" -> event.description)
+  }
+
+  it should "deserialize IntMap (Object values, duplicate keys - default mode)" in {
+    val mapper = newMapper
+    val json = """{"1": 123, "2": 123, "2": 123.456}"""
+    val read = mapper.readValue(json, classOf[mutable.LongMap[Any]])
+    read(1) shouldEqual 123
+    read(2) shouldEqual 123.456
+  }
+
+  it should "deserialize IntMap (Object values, duplicate keys - optional mode)" in {
+    val mapper = newMapper
+    val json = """{"1": 123, "2": 123, "2": 123.456}"""
+    val parser = new WithDupsParser(mapper.createParser(json))
+    val read = try {
+      mapper.readValue(parser, classOf[mutable.LongMap[Any]])
+    } finally {
+      parser.close()
+    }
+    read(1) shouldEqual 123
+    val expected = new java.util.ArrayList[Object]()
+    expected.add(java.lang.Integer.valueOf(123))
+    expected.add(java.lang.Double.valueOf(123.456))
+    read(2) shouldEqual expected
+  }
+
+  it should "deserialize IntMap (Double values, duplicate key mode is ignored)" in {
+    val mapper = newMapper
+    val json = """{"1": "123", "2": "123", "2": "123.456"}"""
+    val parser = new WithDupsParser(mapper.createParser(json))
+    val read = try {
+      mapper.readValue(parser, new TypeReference[mutable.LongMap[String]] {})
+    } finally {
+      parser.close()
+    }
+    read(1) shouldEqual "123"
+    read(2) shouldEqual "123.456"
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/WithDupsParser.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/WithDupsParser.scala
@@ -1,0 +1,10 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.core.{JsonParser, StreamReadCapability}
+import com.fasterxml.jackson.core.util.{JacksonFeatureSet, JsonParserDelegate}
+
+class WithDupsParser(p: JsonParser) extends JsonParserDelegate(p) {
+  override def getReadCapabilities: JacksonFeatureSet[StreamReadCapability] = {
+    super.getReadCapabilities.`with`(StreamReadCapability.DUPLICATE_PROPERTIES)
+  }
+}


### PR DESCRIPTION
Related to https://github.com/FasterXML/jackson-databind/issues/3484

This shows that StreamReadCapability.DUPLICATE_PROPERTIES works with Scala IntMap and LongMap. It is expected that other Scala maps will need bigger changes to get StreamReadCapability.DUPLICATE_PROPERTIES  to work.