### PR TITLE
add (broken) test for XML serialization of Scala Iterator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % Test,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % Test,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion % Test,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % jacksonVersion % Test,
   "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonVersion % Test,
   "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion % Test,
   "javax.ws.rs" % "javax.ws.rs-api" % "2.1.1" % Test,

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/XmlSerializationTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/XmlSerializationTest.scala
@@ -1,0 +1,20 @@
+package com.fasterxml.jackson.module.scala.ser
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.module.scala.ser.XmlSerializationTest.IteratorWrapper
+import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonTest}
+
+object XmlSerializationTest {
+  case class IteratorWrapper(id: String, iterator: Iterator[String])
+}
+
+class XmlSerializationTest extends JacksonTest {
+  val module = DefaultScalaModule
+  val xmlMapper = XmlMapper.builder().addModule(DefaultScalaModule).build()
+
+  "An XmlMapper" should "serialize a Scala Iterator" in {
+    val wrapper = IteratorWrapper("id1", Seq("1", "2", "3").iterator)
+    val xml = xmlMapper.writeValueAsString(wrapper)
+    println(xml)
+  }
+}

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/XmlSerializationTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/XmlSerializationTest.scala
@@ -1,10 +1,11 @@
 package com.fasterxml.jackson.module.scala.ser
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import com.fasterxml.jackson.module.scala.ser.XmlSerializationTest.IteratorWrapper
+import com.fasterxml.jackson.module.scala.ser.XmlSerializationTest._
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, JacksonTest}
 
 object XmlSerializationTest {
+  case class SeqWrapper(id: String, seq: Seq[String])
   case class IteratorWrapper(id: String, iterator: Iterator[String])
 }
 
@@ -14,6 +15,12 @@ class XmlSerializationTest extends JacksonTest {
 
   "An XmlMapper" should "serialize a Scala Iterator" in {
     val wrapper = IteratorWrapper("id1", Seq("1", "2", "3").iterator)
+    val xml = xmlMapper.writeValueAsString(wrapper)
+    println(xml)
+  }
+
+  it should "serialize a Scala Seq" in {
+    val wrapper = SeqWrapper("id1", Seq("1", "2", "3"))
     val xml = xmlMapper.writeValueAsString(wrapper)
     println(xml)
   }


### PR DESCRIPTION
Relates to https://github.com/FasterXML/jackson-dataformat-xml/pull/597

Scala Iterator class does not implement Java Iterator interface but offers a similar API.

The proposed changes in https://github.com/FasterXML/jackson-dataformat-xml/pull/597 won't work for Scala Iterators.

This is not a major problem - noone is complaining yet. Probably not many Scala users using jackson-dataformat-xml and if they are, they probably are not very likely to use Iterators in their DTOs.