### PR TITLE
stop JavaAnnotationInspector from looking at non-Scala classes

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/JavaAnnotationIntrospector.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/JavaAnnotationIntrospector.scala
@@ -15,7 +15,7 @@ object JavaAnnotationIntrospector extends NopAnnotationIntrospector {
 
   override def findImplicitPropertyName(param: AnnotatedMember): String = {
     val result = param match {
-      case param: AnnotatedParameter => {
+      case param: AnnotatedParameter if ScalaAnnotationIntrospector.isMaybeScalaBeanType(param.getDeclaringClass) => {
         val index = param.getIndex
         val owner = param.getOwner
         owner.getAnnotated match {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -230,7 +230,7 @@ object ScalaAnnotationIntrospector extends NopAnnotationIntrospector with ValueI
   private def isScalaPackage(pkg: Option[Package]): Boolean =
     pkg.exists(_.getName.startsWith("scala."))
 
-  private def isMaybeScalaBeanType(cls: Class[_]): Boolean =
+  private[introspect] def isMaybeScalaBeanType(cls: Class[_]): Boolean =
     (cls.extendsScalaClass(ScalaAnnotationIntrospectorModule.shouldSupportScala3Classes()) || cls.hasSignature) &&
       !isScalaPackage(Option(cls.getPackage))
 


### PR DESCRIPTION
cause of #644 