### PR TITLE
include ScalaObjectDeserializerModule in DefaultScalaModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ val mapper = JsonMapper.builder()
 
 One Scala module that isn't part of `DefaultScalaModule` is `ScalaObjectDeserializerModule`. This module is used to
 ensure that deserialization to a Scala object does not create a new instance of the object.
-This latter module is not yet included in `DefaultScalaModule` for backward compatibility reasons.
-It is included in the v3.0.0, which is still under development.
+This latter module is not yet included in `DefaultScalaModule` but will be included in v2.16.0.
+It is already included in v3.0.0, which is still under development.
 
 ## DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES
 

--- a/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/DefaultScalaModule.scala
@@ -1,6 +1,10 @@
 package com.fasterxml.jackson.module.scala
 
-import com.fasterxml.jackson.module.scala.deser.{ScalaNumberDeserializersModule, UntypedObjectDeserializerModule}
+import com.fasterxml.jackson.module.scala.deser.{
+  ScalaNumberDeserializersModule,
+  ScalaObjectDeserializerModule,
+  UntypedObjectDeserializerModule
+}
 import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
 
 /**
@@ -25,6 +29,7 @@ class DefaultScalaModule
      with MapModule
      with SetModule
      with ScalaNumberDeserializersModule
+     with ScalaObjectDeserializerModule
      with ScalaAnnotationIntrospectorModule
      with UntypedObjectDeserializerModule
      with EitherModule

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonAutoDetect, PropertyAccessor}
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import com.fasterxml.jackson.module.scala.deser.CaseObjectDeserializerTest.{Foo, TestObject}
+import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
 
 object CaseObjectDeserializerTest {
   case object TestObject
@@ -13,12 +14,11 @@ object CaseObjectDeserializerTest {
   }
 }
 
-//see also CaseObjectScala2DeserializerTest
 class CaseObjectDeserializerTest extends DeserializerTest {
   def module = DefaultScalaModule
 
-  "An ObjectMapper with DefaultScalaModule and ScalaObjectDeserializerModule" should "deserialize a case object and not create a new instance" in {
-    val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(ScalaObjectDeserializerModule).build()
+  "An ObjectMapper with DefaultScalaModule" should "deserialize a case object and not create a new instance" in {
+    val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
     val original = TestObject
     val json = mapper.writeValueAsString(original)
     val deserialized = mapper.readValue(json, TestObject.getClass)
@@ -36,7 +36,6 @@ class CaseObjectDeserializerTest extends DeserializerTest {
   it should "deserialize Foo and not create a new instance (visibility settings)" in {
     val mapper = JsonMapper.builder()
       .addModule(DefaultScalaModule)
-      .addModule(ScalaObjectDeserializerModule)
       .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
       .visibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
       .build()
@@ -46,10 +45,9 @@ class CaseObjectDeserializerTest extends DeserializerTest {
     assert(deserialized == original)
   }
 
-  "An ObjectMapper with ClassTagExtensions and ScalaObjectDeserializerModule" should "deserialize a case object and not create a new instance" in {
+  "An ObjectMapper with ClassTagExtensions and DefaultScalaModule" should "deserialize a case object and not create a new instance" in {
     val mapper = JsonMapper.builder()
       .addModule(DefaultScalaModule)
-      .addModule(ScalaObjectDeserializerModule)
       .build() :: ClassTagExtensions
     val original = TestObject
     val json = mapper.writeValueAsString(original)
@@ -57,8 +55,8 @@ class CaseObjectDeserializerTest extends DeserializerTest {
     assert(deserialized == original)
   }
 
-  "An ObjectMapper with DefaultScalaModule but not ScalaObjectDeserializerModule" should "deserialize a case object but create a new instance" in {
-    val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
+  "An ObjectMapper without ScalaObjectDeserializerModule" should "deserialize a case object but create a new instance" in {
+    val mapper = JsonMapper.builder().addModule(ScalaAnnotationIntrospectorModule).build()
     val original = TestObject
     val json = mapper.writeValueAsString(original)
     val deserialized = mapper.readValue(json, TestObject.getClass)


### PR DESCRIPTION
see #601 

I think it is safe to apply same change for v2.16.0 release