### PR TITLE
Fix regression in Map deserialization in Scala 2.13 when default typing is enabled

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/DefaultTypingMapDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/DefaultTypingMapDeserializerTest.scala
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import scala.collection.immutable
+
+class DefaultTypingMapDeserializerTest extends DeserializerTest {
+
+  def module: DefaultScalaModule.type = DefaultScalaModule
+
+  override def newMapper: ObjectMapper = {
+    val mapper = super.newMapper
+    mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator)
+  }
+
+  "Scala Module" should "deserialize immutable Map when default typing enabled" in {
+    val map = HasMap(immutable.Map("one" -> "one", "two" -> "two"))
+
+    val mapper = newMapper
+
+    val json = mapper.writeValueAsString(map)
+    // Was failing in Scala 2.13+ with:
+    // > Could not resolve type id 'scala.collection.convert.JavaCollectionWrappers$MapWrapper' as a subtype of
+    // > `scala.collection.immutable.Map<java.lang.String,java.lang.String>`: Not a subtype
+    //
+    // prior the changing MapSerializerModule.scala to use an inner class for MapWrapper
+    val read = mapper.readValue(json, classOf[HasMap])
+
+    read shouldEqual map
+  }
+
+}
+
+case class HasMap(m: Map[String, String])


### PR DESCRIPTION
This Map serializer is implemented in terms of the Java version and is somewhat fragile, as discussed in #643 / #470.

This commit ensures that the wrapper class is a member class in both Scala and Java.

That results in this JSON as the serializer code chooses not to put the inner class name in the type annotation.

```
{"m":["scala.collection.immutable.Map",{"one":"one","two":"two"}]}
```

Fixes #643