### PR TITLE
BigIntOptionAnyValHolder in AnyValSerializerTest fails in scala 2.11 and scala 3.3

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/AnyValSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/AnyValSerializerTest.scala
@@ -8,6 +8,7 @@ object AnyValSerializerTest {
 
   case class BigIntAnyVal(underlying: BigInt) extends AnyVal
   case class BigIntAnyValHolder(value: BigIntAnyVal)
+  case class BigIntOptionAnyValHolder(value: Option[BigIntAnyVal])
 }
 
 //see AnyVal2SerializerTest for cases that only work with Scala2 and Scala3.3 but not earlier versions of Scala3
@@ -26,6 +27,7 @@ class AnyValSerializerTest extends BaseFixture {
     val value = BigIntAnyVal(42)
     mapper.writeValueAsString(value) shouldBe """{"underlying":42}"""
     mapper.writeValueAsString(BigIntAnyValHolder(value)) shouldBe """{"value":42}"""
+    mapper.writeValueAsString(BigIntOptionAnyValHolder(Some(value))) shouldBe """{"value":{"underlying":42}}"""
   }
 
 }


### PR DESCRIPTION
This test fails in scala 2.11 and scala 3.3 with the follwoing error

```
com.fasterxml.jackson.databind.JsonMappingException: class com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest$BigIntAnyVal cannot be cast to class java.lang.Number (com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest$BigIntAnyVal is in unnamed module of loader sbt.internal.LayeredClassLoader @7e8791ff; java.lang.Number is in module java.base of loader 'bootstrap') (through reference chain: com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest$BigIntOptionAnyValHolder["value"])
[info]   at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:402)
[info]   at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:361)
[info]   at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:323)
[info]   at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:778)
[info]   at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:184)
[info]   at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
[info]   at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
[info]   at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4801)
[info]   at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:4042)
[info]   at com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest.$anonfun$2(AnyValSerializerTest.scala:30)
[info]   ...
[info]   Cause: java.lang.ClassCastException: class com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest$BigIntAnyVal cannot be cast to class java.lang.Number (com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest$BigIntAnyVal is in unnamed module of loader sbt.internal.LayeredClassLoader @7e8791ff; java.lang.Number is in module java.base of loader 'bootstrap')
[info]   at com.fasterxml.jackson.databind.ser.std.NumberSerializer.serialize(NumberSerializer.java:23)
[info]   at com.fasterxml.jackson.databind.ser.std.ReferenceTypeSerializer.serialize(ReferenceTypeSerializer.java:389)
[info]   at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732)
[info]   at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
[info]   at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:184)
[info]   at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
[info]   at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
[info]   at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4801)
[info]   at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:4042)
[info]   at com.fasterxml.jackson.module.scala.ser.AnyValSerializerTest.$anonfun$2(AnyValSerializerTest.scala:30)
```