### PR TITLE
Remove paragraph about ScalaObjectDeserializerModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ val mapper = JsonMapper.builder()
   .build()
 ```
 
-One Scala module that isn't part of `DefaultScalaModule` is `ScalaObjectDeserializerModule`. This module is used to
-ensure that deserialization to a Scala object does not create a new instance of the object.
-This latter module is not yet included in `DefaultScalaModule` but will be included in v2.16.0.
-It is already included in v3.0.0, which is still under development.
-
 ## DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES
 
 It is recommended that Scala users enable `DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES`. This feature means that when you


### PR DESCRIPTION
`ScalaObjectDeserializerModule` is part of `DefaultScalaModule` since version 2.16.0.