### PR TITLE
handle token reading issue in ScalaObjectDeserializer

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.{JsonParser, JsonToken}
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind._
@@ -11,7 +11,14 @@ import scala.languageFeature.postfixOps
 import scala.util.control.NonFatal
 
 private class ScalaObjectDeserializer(value: Any) extends StdDeserializer[Any](classOf[Any]) {
-  override def deserialize(p: JsonParser, ctxt: DeserializationContext): Any = value
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): Any = {
+    if (p.currentToken() != JsonToken.END_OBJECT) {
+      while (p.nextToken() != JsonToken.END_OBJECT) {
+        // consume the object
+      }
+    }
+    value
+  }
 }
 
 private object ScalaObjectDeserializerResolver extends Deserializers.Base {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.scala.deser
 
 import com.fasterxml.jackson.annotation.{JsonAutoDetect, PropertyAccessor}
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import com.fasterxml.jackson.module.scala.deser.CaseObjectDeserializerTest.{Foo, TestObject}
@@ -21,6 +22,17 @@ class CaseObjectDeserializerTest extends DeserializerTest {
     val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
     val original = TestObject
     val json = mapper.writeValueAsString(original)
+    val deserialized = mapper.readValue(json, TestObject.getClass)
+    assert(deserialized === original)
+  }
+
+  it should "deserialize a case object and not create a new instance (FAIL_ON_TRAILING_TOKENS enabled)" in {
+    val mapper = newBuilder
+      .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+      .build()
+    val original = TestObject
+    val json = mapper.writeValueAsString(original)
+    json shouldEqual "{}"
     val deserialized = mapper.readValue(json, TestObject.getClass)
     assert(deserialized === original)
   }


### PR DESCRIPTION
This can lead to stray parsing tokens that can cause later parsing to fail.

Discovered in #701 