### PR TITLE
drop scala 2.11 and remove paranamer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.11.12, 2.12.20, 2.13.16, 3.3.5]
+        scala: [2.12.20, 2.13.16, 3.3.5]
         java: [zulu@17, zulu@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -99,16 +99,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Download target directories (2.11.12)
-        uses: actions/download-artifact@v4
-        with:
-          name: target-${{ matrix.os }}-2.11.12-${{ matrix.java }}
-
-      - name: Inflate target directories (2.11.12)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Download target directories (2.12.20)
         uses: actions/download-artifact@v4

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / version := "3.0.0-rc1-SNAPSHOT"
 val scala213Version = "2.13.16"
 ThisBuild / scalaVersion := scala213Version
 
-ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.20", scala213Version, "3.3.5")
+ThisBuild / crossScalaVersions := Seq("2.12.20", scala213Version, "3.3.5")
 
 sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository := "s01.oss.sonatype.org"
@@ -110,14 +110,13 @@ Test / unmanagedSourceDirectories ++= {
 libraryDependencies ++= Seq(
   "tools.jackson.core" % "jackson-core" % jacksonVersion changing(),
   "tools.jackson.core" % "jackson-databind" % jacksonVersion changing(),
-  "com.thoughtworks.paranamer" % "paranamer" % "2.8",
   "tools.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % Test changing(),
   "tools.jackson.datatype" % "jackson-datatype-guava" % jacksonVersion % Test changing(),
   "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2" % Test,
   "tools.jackson.jaxrs" % "jackson-jaxrs-json-provider" % jacksonVersion % Test changing(),
   "javax.ws.rs" % "javax.ws.rs-api" % "2.1.1" % Test,
   "io.swagger" % "swagger-core" % "1.6.8" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.18" % Test
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
 
 // build.properties

--- a/src/main/scala/tools/jackson/module/scala/introspect/JavaParameterIntrospector.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/JavaParameterIntrospector.scala
@@ -1,30 +1,18 @@
 package tools.jackson.module.scala.introspect
 
-import com.thoughtworks.paranamer.{BytecodeReadingParanamer, CachingParanamer}
-
 import java.lang.reflect.{Constructor, Field, Method, Parameter}
-import scala.util.Try
 
 private[introspect] object JavaParameterIntrospector {
 
-  private val paranamer = new CachingParanamer(new BytecodeReadingParanamer)
-
   def getCtorParamNames(ctor: Constructor[_]): IndexedSeq[String] = {
-    Try(paranamer.lookupParameterNames(ctor, false))
-      .getOrElse(ctor.getParameters.map(_.getName))
-      .toIndexedSeq
+    ctor.getParameters.map(_.getName).toIndexedSeq
   }
 
   def getMethodParamNames(mtd: Method): IndexedSeq[String] = {
-    Try(paranamer.lookupParameterNames(mtd, false))
-      .getOrElse(mtd.getParameters.map(_.getName))
-      .toIndexedSeq
+    mtd.getParameters.map(_.getName).toIndexedSeq
   }
 
-  def getFieldName(field: Field): String = {
-    Try(paranamer.lookupParameterNames(field, false).headOption.getOrElse(None.orNull))
-      .getOrElse(field.getName)
-  }
+  def getFieldName(field: Field): String = field.getName
 
   def getParameterName(parameter: Parameter): String = parameter.getName
 }


### PR DESCRIPTION
Scala 2.11 is pretty old. Paranamer is only now needed by Scala 2.11 but it doesn't seem worth complicating the build to achieve this.