### PR TITLE
Add Java DSL so that Java users can more easily add the Scala Module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 bomFormat := "xml"
 
+Compile / compileOrder := CompileOrder.Mixed
+
 val jacksonVersion = "3.0.0-rc1-SNAPSHOT"
 
 publishTo := {

--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,6 @@ resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 bomFormat := "xml"
 
-Compile / compileOrder := CompileOrder.Mixed
-
 val jacksonVersion = "3.0.0-rc1-SNAPSHOT"
 
 publishTo := {
@@ -80,7 +78,8 @@ scalacOptions ++= {
 // and we use it.
 //scalacOptions in (Compile, compile) += "-Xfatal-warnings"
 
-compileOrder := CompileOrder.JavaThenScala
+Compile / compileOrder := CompileOrder.Mixed
+Test / compileOrder := CompileOrder.JavaThenScala
 
 Compile / unmanagedSourceDirectories ++= {
   if (scalaReleaseVersion.value > 2) {

--- a/src/main/java/tools/jackson/module/scala/javadsl/DefaultScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/DefaultScalaModule.java
@@ -1,0 +1,7 @@
+package tools.jackson.module.scala.javadsl;
+
+public final class DefaultScalaModule {
+    public static tools.jackson.module.scala.JacksonModule getInstance() {
+        return tools.jackson.module.scala.DefaultScalaModule$.MODULE$;
+    }
+}

--- a/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
@@ -1,7 +1,45 @@
 package tools.jackson.module.scala.javadsl;
 
+import tools.jackson.module.scala.*;
+
 public final class ScalaModule {
     public static tools.jackson.module.scala.ScalaModule.Builder builder() {
         return tools.jackson.module.scala.ScalaModule$.MODULE$.builder();
+    }
+
+    public static EitherModule eitherModule() {
+        return EitherModule$.MODULE$;
+    }
+
+    public static EnumerationModule enumerationModule() {
+        return EnumerationModule$.MODULE$;
+    }
+
+    public static IteratorModule iteratorModule() {
+        return IteratorModule$.MODULE$;
+    }
+
+    public static IterableModule iterableModule() {
+        return IterableModule$.MODULE$;
+    }
+
+    public static OptionModule optionModule() {
+        return OptionModule$.MODULE$;
+    }
+
+    public static TupleModule tupleModule() {
+        return TupleModule$.MODULE$;
+    }
+
+    public static MapModule mapModule() {
+        return MapModule$.MODULE$;
+    }
+
+    public static SetModule setModule() {
+        return SetModule$.MODULE$;
+    }
+
+    public static SymbolModule symbolModule() {
+        return SymbolModule$.MODULE$;
     }
 }

--- a/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
@@ -16,6 +16,9 @@ public final class ScalaModule {
         return EitherModule$.MODULE$;
     }
 
+    /**
+     * EnumModule is not available in Scala 2.x - as it relates to Scala 3 <code>enum</code>s.
+     */
     public static JacksonModule enumModule() {
         try {
             Class<?> objectClass = Class.forName("tools.jackson.module.scala.EnumModule$");

--- a/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
@@ -1,0 +1,7 @@
+package tools.jackson.module.scala.javadsl;
+
+public final class ScalaModule {
+    public static tools.jackson.module.scala.ScalaModule.Builder builder() {
+        return tools.jackson.module.scala.ScalaModule$.MODULE$.builder();
+    }
+}

--- a/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
@@ -1,14 +1,30 @@
 package tools.jackson.module.scala.javadsl;
 
 import tools.jackson.module.scala.*;
+import tools.jackson.module.scala.deser.*;
+import tools.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 public final class ScalaModule {
     public static tools.jackson.module.scala.ScalaModule.Builder builder() {
-        return tools.jackson.module.scala.ScalaModule$.MODULE$.builder();
+        return ScalaModule$.MODULE$.builder();
     }
 
     public static EitherModule eitherModule() {
         return EitherModule$.MODULE$;
+    }
+
+    public static JacksonModule enumModule() {
+        try {
+            Class<?> objectClass = Class.forName("tools.jackson.module.scala.EnumModule$");
+            VarHandle varHandle = MethodHandles.publicLookup().findStaticVarHandle(
+                    objectClass, "MODULE$", objectClass);
+            return (JacksonModule) varHandle.get();
+        } catch (Throwable t) {
+            return null;
+        }
     }
 
     public static EnumerationModule enumerationModule() {
@@ -41,5 +57,21 @@ public final class ScalaModule {
 
     public static SymbolModule symbolModule() {
         return SymbolModule$.MODULE$;
+    }
+
+    public static ScalaAnnotationIntrospectorModule scalaAnnotationIntrospectorModule() {
+        return ScalaAnnotationIntrospectorModule.newStandaloneInstance();
+    }
+
+    public static ScalaNumberDeserializersModule scalaNumberDeserializersModule() {
+        return ScalaNumberDeserializersModule$.MODULE$;
+    }
+
+    public static ScalaObjectDeserializerModule scalaObjectDeserializerModule() {
+        return ScalaObjectDeserializerModule$.MODULE$;
+    }
+
+    public static UntypedObjectDeserializerModule untypedObjectDeserializerModule() {
+        return UntypedObjectDeserializerModule$.MODULE$;
     }
 }

--- a/src/test/scala-3/tools/jackson/module/scala/javadsl/Scala3ModuleJavaDslTest.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/javadsl/Scala3ModuleJavaDslTest.scala
@@ -1,0 +1,10 @@
+package tools.jackson.module.scala.javadsl
+
+import tools.jackson.module.scala.{ BaseSpec, EnumModule }
+
+class ScalaModule3Test extends BaseSpec {
+  "Java DSL ScalaModule" should "support EnumModule (Scala 3 only)" in {
+    val module = ScalaModule.enumModule()
+    module shouldBe an[EnumModule]
+  }
+}

--- a/src/test/scala/tools/jackson/module/scala/JavaDslTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/JavaDslTest.scala
@@ -1,0 +1,11 @@
+package tools.jackson.module.scala
+
+class JavaDslTest extends BaseSpec {
+  "Java DSL" should "support getting DefaultScalaModule" in {
+    javadsl.DefaultScalaModule.getInstance() shouldBe DefaultScalaModule
+  }
+  it should "support ScalaModule builder" in {
+    val builder = javadsl.ScalaModule.builder().addAllBuiltinModules()
+    builder.hasModule(IteratorModule) shouldBe true
+  }
+}

--- a/src/test/scala/tools/jackson/module/scala/javadsl/ScalaModuleJavaDslTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/javadsl/ScalaModuleJavaDslTest.scala
@@ -1,0 +1,18 @@
+package tools.jackson.module.scala.javadsl
+
+import tools.jackson.module.scala._
+
+class ScalaModuleJavaDslTest extends BaseSpec {
+  "Java DSL ScalaModule" should "support EnumerationModule" in {
+    javadsl.ScalaModule.enumerationModule() shouldBe an[EnumerationModule]
+  }
+  it should "support EitherModule" in {
+    javadsl.ScalaModule.eitherModule() shouldBe an[EitherModule]
+  }
+  it should "support IterableModule" in {
+    javadsl.ScalaModule.iterableModule() shouldBe an[IterableModule]
+  }
+  it should "support IteratorModule" in {
+    javadsl.ScalaModule.iteratorModule() shouldBe an[IteratorModule]
+  }
+}


### PR DESCRIPTION
Some Java users may still want to add the Scala Module to their Jackson set up.
Can already be done but the class names are a bit awkward (need to add `$` to end of class names, etc.).