### PR TITLE
deserialization: treat missing/null input for Scala collections as meaning empty collection

### DIFF
--- a/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala-2.11/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -1,0 +1,147 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import java.util
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import com.fasterxml.jackson.databind.deser.std.{CollectionDeserializer, ContainerDeserializerBase, StdValueInstantiator}
+import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.language.higherKinds
+
+abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deserializers.Base {
+  type Collection[A] = CC[A]
+  type Factory = CF[CC]
+  type Builder[A] = mutable.Builder[A, _ <: Collection[A]]
+
+  // Subclasses need to implement the following:
+  val CLASS_DOMAIN: Class[_]
+  val factories: Iterable[(Class[_], Factory)]
+  def builderFor[A](cf: Factory, valueType: JavaType): Builder[A]
+
+  def builderFor[A](cls: Class[_], valueType: JavaType): Builder[A] = factories
+    .find(_._1.isAssignableFrom(cls))
+    .map(_._2)
+    .map(builderFor[A](_, valueType))
+    .getOrElse(throw new IllegalStateException(s"Could not find deserializer for ${cls.getCanonicalName}. File issue on github:fasterxml/jackson-scala-module."))
+
+  override def findCollectionLikeDeserializer(collectionType: CollectionLikeType,
+                                              config: DeserializationConfig,
+                                              beanDesc: BeanDescription,
+                                              elementTypeDeserializer: TypeDeserializer,
+                                              elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] = {
+    if (!CLASS_DOMAIN.isAssignableFrom(collectionType.getRawClass)) None.orNull
+    else {
+      val deser = elementDeserializer.asInstanceOf[JsonDeserializer[AnyRef]]
+      val instantiator = new Instantiator(config, collectionType, collectionType.getContentType)
+      new Deserializer(collectionType, deser, elementTypeDeserializer, instantiator)
+    }
+  }
+
+  protected def sortFactories(factories: IndexedSeq[(Class[_], Factory)]): Seq[(Class[_], Factory)] = {
+    val cs = factories.toArray
+    val output = new ListBuffer[(Class[_], Factory)]()
+
+    val remaining = cs.map(_ => 1)
+    val adjMatrix = Array.ofDim[Int](cs.length, cs.length)
+
+    // Build the adjacency matrix. Only mark the in-edges.
+    for (i <- cs.indices; j <- cs.indices) {
+      val (ic, _) = cs(i)
+      val (jc, _) = cs(j)
+
+      if (i != j && ic.isAssignableFrom(jc)) {
+        adjMatrix(i)(j) = 1
+      }
+    }
+
+    // While we haven't removed every node, remove all nodes with 0 degree in-edges.
+    while (output.length < cs.length) {
+      val startLength = output.length
+
+      for (i <- cs.indices) {
+        if (remaining(i) == 1 && dotProduct(adjMatrix(i), remaining) == 0) {
+          output += factories(i)
+          remaining(i) = 0
+        }
+      }
+
+      // If we couldn't remove any nodes, it means we've found a cycle. Realistically this should never happen.
+      if (output.length == startLength) {
+        throw new IllegalStateException("Companions contain a cycle.")
+      }
+    }
+
+    output.toSeq
+  }
+
+  private def dotProduct(a: Array[Int], b: Array[Int]): Int = {
+    if (a.length != b.length) throw new IllegalArgumentException()
+
+    a.indices.map(i => a(i) * b(i)).sum
+  }
+
+  private class BuilderWrapper[A](val builder: Builder[A]) extends util.AbstractCollection[A] {
+    var size = 0
+
+    override def add(e: A): Boolean = { builder += e; size += 1; true }
+
+    // Required by AbstractCollection, but not implemented
+    override def iterator(): util.Iterator[A] = None.orNull
+
+    def setInitialValue(init: Collection[A]): Unit = init.asInstanceOf[Iterable[A]].foreach(add)
+  }
+
+  private class Instantiator(config: DeserializationConfig, collectionType: JavaType, valueType: JavaType)
+    extends StdValueInstantiator(config, collectionType) {
+
+    override def canCreateUsingDefault = true
+
+    override def createUsingDefault(ctxt: DeserializationContext) =
+      new BuilderWrapper[AnyRef](builderFor[AnyRef](collectionType.getRawClass, valueType))
+  }
+
+  private class Deserializer[A](collectionType: JavaType, containerDeserializer: CollectionDeserializer)
+    extends ContainerDeserializerBase[CC[A]](collectionType)
+      with ContextualDeserializer {
+
+    def this(collectionType: JavaType, valueDeser: JsonDeserializer[Object], valueTypeDeser: TypeDeserializer, valueInstantiator: ValueInstantiator) = {
+      this(collectionType, new CollectionDeserializer(collectionType, valueDeser, valueTypeDeser, valueInstantiator))
+    }
+
+    override def createContextual(ctxt: DeserializationContext, property: BeanProperty): Deserializer[A] = {
+      val newDelegate = containerDeserializer.createContextual(ctxt, property)
+      new Deserializer(collectionType, newDelegate)
+    }
+
+    override def getContentType: JavaType = containerDeserializer.getContentType
+
+    override def getContentDeserializer: JsonDeserializer[AnyRef] = containerDeserializer.getContentDeserializer
+
+    override def deserialize(jp: JsonParser, ctxt: DeserializationContext): CC[A] = {
+      containerDeserializer.deserialize(jp, ctxt) match {
+        case wrapper: BuilderWrapper[_] => wrapper.builder.result().asInstanceOf[CC[A]]
+      }
+    }
+
+    override def deserialize(jp: JsonParser, ctxt: DeserializationContext, intoValue: CC[A]): CC[A] = {
+      val bw = newBuilderWrapper(ctxt)
+      bw.setInitialValue(intoValue.asInstanceOf[CC[AnyRef]])
+      containerDeserializer.deserialize(jp, ctxt, bw) match {
+        case wrapper: BuilderWrapper[_] => wrapper.builder.result().asInstanceOf[CC[A]]
+      }
+    }
+
+    override def getEmptyValue(ctxt: DeserializationContext): Object = {
+      val bw = newBuilderWrapper(ctxt)
+      bw.builder.result().asInstanceOf[Object]
+    }
+
+    private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef] = {
+      containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]
+    }
+  }
+}

--- a/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala-2.12/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.language.higherKinds
 
 abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deserializers.Base {
   type Collection[A] = CC[A]
@@ -139,9 +138,6 @@ abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deser
       val bw = newBuilderWrapper(ctxt)
       bw.builder.result().asInstanceOf[Object]
     }
-
-    override def getNullValue(ctxt: DeserializationContext): CC[A] =
-      getEmptyValue(ctxt).asInstanceOf[CC[A]]
 
     private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef] = {
       containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]

--- a/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala-2.13/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -1,0 +1,149 @@
+package com.fasterxml.jackson.module.scala.deser
+
+import java.util
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import com.fasterxml.jackson.databind.deser.std.{CollectionDeserializer, ContainerDeserializerBase, StdValueInstantiator}
+import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deserializers.Base {
+  type Collection[A] = CC[A]
+  type Factory = CF[CC]
+  type Builder[A] = mutable.Builder[A, _ <: Collection[A]]
+
+  // Subclasses need to implement the following:
+  val CLASS_DOMAIN: Class[_]
+  val factories: Iterable[(Class[_], Factory)]
+  def builderFor[A](cf: Factory, valueType: JavaType): Builder[A]
+
+  def builderFor[A](cls: Class[_], valueType: JavaType): Builder[A] = factories
+    .find(_._1.isAssignableFrom(cls))
+    .map(_._2)
+    .map(builderFor[A](_, valueType))
+    .getOrElse(throw new IllegalStateException(s"Could not find deserializer for ${cls.getCanonicalName}. File issue on github:fasterxml/jackson-scala-module."))
+
+  override def findCollectionLikeDeserializer(collectionType: CollectionLikeType,
+                                              config: DeserializationConfig,
+                                              beanDesc: BeanDescription,
+                                              elementTypeDeserializer: TypeDeserializer,
+                                              elementDeserializer: JsonDeserializer[_]): JsonDeserializer[_] = {
+    if (!CLASS_DOMAIN.isAssignableFrom(collectionType.getRawClass)) None.orNull
+    else {
+      val deser = elementDeserializer.asInstanceOf[JsonDeserializer[AnyRef]]
+      val instantiator = new Instantiator(config, collectionType, collectionType.getContentType)
+      new Deserializer(collectionType, deser, elementTypeDeserializer, instantiator)
+    }
+  }
+
+  protected def sortFactories(factories: IndexedSeq[(Class[_], Factory)]): Seq[(Class[_], Factory)] = {
+    val cs = factories.toArray
+    val output = new ListBuffer[(Class[_], Factory)]()
+
+    val remaining = cs.map(_ => 1)
+    val adjMatrix = Array.ofDim[Int](cs.length, cs.length)
+
+    // Build the adjacency matrix. Only mark the in-edges.
+    for (i <- cs.indices; j <- cs.indices) {
+      val (ic, _) = cs(i)
+      val (jc, _) = cs(j)
+
+      if (i != j && ic.isAssignableFrom(jc)) {
+        adjMatrix(i)(j) = 1
+      }
+    }
+
+    // While we haven't removed every node, remove all nodes with 0 degree in-edges.
+    while (output.length < cs.length) {
+      val startLength = output.length
+
+      for (i <- cs.indices) {
+        if (remaining(i) == 1 && dotProduct(adjMatrix(i), remaining) == 0) {
+          output += factories(i)
+          remaining(i) = 0
+        }
+      }
+
+      // If we couldn't remove any nodes, it means we've found a cycle. Realistically this should never happen.
+      if (output.length == startLength) {
+        throw new IllegalStateException("Companions contain a cycle.")
+      }
+    }
+
+    output.toSeq
+  }
+
+  private def dotProduct(a: Array[Int], b: Array[Int]): Int = {
+    if (a.length != b.length) throw new IllegalArgumentException()
+
+    a.indices.map(i => a(i) * b(i)).sum
+  }
+
+  private class BuilderWrapper[A](val builder: Builder[A]) extends util.AbstractCollection[A] {
+    var size = 0
+
+    override def add(e: A): Boolean = { builder += e; size += 1; true }
+
+    // Required by AbstractCollection, but not implemented
+    override def iterator(): util.Iterator[A] = None.orNull
+
+    def setInitialValue(init: Collection[A]): Unit = init.asInstanceOf[Iterable[A]].foreach(add)
+  }
+
+  private class Instantiator(config: DeserializationConfig, collectionType: JavaType, valueType: JavaType)
+    extends StdValueInstantiator(config, collectionType) {
+
+    override def canCreateUsingDefault = true
+
+    override def createUsingDefault(ctxt: DeserializationContext) =
+      new BuilderWrapper[AnyRef](builderFor[AnyRef](collectionType.getRawClass, valueType))
+  }
+
+  private class Deserializer[A](collectionType: JavaType, containerDeserializer: CollectionDeserializer)
+    extends ContainerDeserializerBase[CC[A]](collectionType)
+      with ContextualDeserializer {
+
+    def this(collectionType: JavaType, valueDeser: JsonDeserializer[Object], valueTypeDeser: TypeDeserializer, valueInstantiator: ValueInstantiator) = {
+      this(collectionType, new CollectionDeserializer(collectionType, valueDeser, valueTypeDeser, valueInstantiator))
+    }
+
+    override def createContextual(ctxt: DeserializationContext, property: BeanProperty): Deserializer[A] = {
+      val newDelegate = containerDeserializer.createContextual(ctxt, property)
+      new Deserializer(collectionType, newDelegate)
+    }
+
+    override def getContentType: JavaType = containerDeserializer.getContentType
+
+    override def getContentDeserializer: JsonDeserializer[AnyRef] = containerDeserializer.getContentDeserializer
+
+    override def deserialize(jp: JsonParser, ctxt: DeserializationContext): CC[A] = {
+      containerDeserializer.deserialize(jp, ctxt) match {
+        case wrapper: BuilderWrapper[_] => wrapper.builder.result().asInstanceOf[CC[A]]
+      }
+    }
+
+    override def deserialize(jp: JsonParser, ctxt: DeserializationContext, intoValue: CC[A]): CC[A] = {
+      val bw = newBuilderWrapper(ctxt)
+      bw.setInitialValue(intoValue.asInstanceOf[CC[AnyRef]])
+      containerDeserializer.deserialize(jp, ctxt, bw) match {
+        case wrapper: BuilderWrapper[_] => wrapper.builder.result().asInstanceOf[CC[A]]
+      }
+    }
+
+    override def getEmptyValue(ctxt: DeserializationContext): Object = {
+      val bw = newBuilderWrapper(ctxt)
+      bw.builder.result().asInstanceOf[Object]
+    }
+
+    override def getNullValue(ctxt: DeserializationContext): CC[A] =
+      getEmptyValue(ctxt).asInstanceOf[CC[A]]
+
+    private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef] = {
+      containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]
+    }
+  }
+}

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -105,13 +105,8 @@ abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]] extends Deser
       new BuilderWrapper[AnyRef](builderFor[AnyRef](collectionType.getRawClass, valueType))
   }
 
-  private class ContainerNullValueProvider(containerDeserializer: CollectionDeserializer) extends NullValueProvider {
-    override def getNullValue(ctxt: DeserializationContext): AnyRef = containerDeserializer.getEmptyValue(ctxt)
-    override def getNullAccessPattern: AccessPattern = containerDeserializer.getNullAccessPattern
-  }
-
   private class Deserializer[A](collectionType: JavaType, containerDeserializer: CollectionDeserializer)
-    extends ContainerDeserializerBase[CC[A]](collectionType, new ContainerNullValueProvider(containerDeserializer), None.orNull)
+    extends ContainerDeserializerBase[CC[A]](collectionType)
       with ContextualDeserializer {
 
     def this(collectionType: JavaType, valueDeser: JsonDeserializer[Object], valueTypeDeser: TypeDeserializer, valueInstantiator: ValueInstantiator) = {

--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.`type`.CollectionLikeType
 import com.fasterxml.jackson.databind.deser.std.{CollectionDeserializer, ContainerDeserializerBase, StdValueInstantiator}
-import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, NullValueProvider, ValueInstantiator}
+import com.fasterxml.jackson.databind.deser.{ContextualDeserializer, Deserializers, ValueInstantiator}
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer
-import com.fasterxml.jackson.databind.util.AccessPattern
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -197,10 +197,11 @@ class CaseClassDeserializerTest extends DeserializerTest {
     result shouldEqual ClassWithOnlyUnitField(())
   }
 
-  it should "support deserializing null input for list as empty list" ignore {
+  it should "support deserializing null input for list as empty list" in {
     val input = """{}"""
     val result = deserialize(input, classOf[ListHolder[String]])
-    result.list shouldBe null // ideally should be empty list, Scala users expect no nulls
+    // this was only fixed in 2.19.0
+    result.list shouldBe List.empty
   }
 
   it should "support deserializing null input for list as empty list (JsonSetter annotation)" in {


### PR DESCRIPTION
Scala users expect nulls to be avoided. Generate an empty collection to represent the missing collection instead of representing it as null.