### PR TITLE
deserialization for collections, null leads to empty collection

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/GenericFactoryDeserializerResolver.scala
@@ -145,6 +145,8 @@ abstract class GenericFactoryDeserializerResolver[CC[_], CF[X[_]]](config: Scala
       bw.builder.result().asInstanceOf[Object]
     }
 
+    override def getNullValue(ctxt: DeserializationContext): Object = getEmptyValue(ctxt)
+
     private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef] = {
       containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef]]
     }

--- a/src/main/scala/tools/jackson/module/scala/deser/GenericMapFactoryDeserializerResolver.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/GenericMapFactoryDeserializerResolver.scala
@@ -166,6 +166,8 @@ abstract class GenericMapFactoryDeserializerResolver[CC[K, V], CF[X[_, _]]](conf
       bw.builder.result().asInstanceOf[Object]
     }
 
+    override def getNullValue(ctxt: DeserializationContext): Object = getEmptyValue(ctxt)
+
     private def newBuilderWrapper(ctxt: DeserializationContext): BuilderWrapper[AnyRef, AnyRef] = {
       containerDeserializer.getValueInstantiator.createUsingDefault(ctxt).asInstanceOf[BuilderWrapper[AnyRef, AnyRef]]
     }

--- a/src/test/scala/tools/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -199,10 +199,11 @@ class CaseClassDeserializerTest extends DeserializerTest {
     result shouldEqual ClassWithOnlyUnitField(())
   }
 
-  it should "support deserializing null input for list as empty list" ignore {
+  it should "support deserializing null input for list as empty list" in {
     val input = """{}"""
     val result = deserialize(input, classOf[ListHolder[String]])
-    result.list shouldBe null // ideally should be empty list, Scala users expect no nulls
+    // this result has only happened since 3.0.0 - befpre result.list was null
+    result.list shouldBe List.empty
   }
 
   it should "support deserializing null input for list as empty list (JsonSetter annotation)" in {


### PR DESCRIPTION
Jackson 2 will give you a null if you deserialize and the collection data is missing in the input JSON.
This change means that you will get an empty collection instead.