### PR TITLE
Fix an issue with deprecated `PropertyNamingStrategy.SNAKE_CASE` used by tests

### DIFF
--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -4,7 +4,7 @@ package deser
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonSetter, Nulls}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.{DeserializationFeature, JsonMappingException, ObjectMapper, ObjectReader, PropertyNamingStrategy}
+import com.fasterxml.jackson.databind.{DeserializationFeature, JsonMappingException, ObjectMapper, ObjectReader, PropertyNamingStrategies}
 import com.fasterxml.jackson.module.scala.ser.{ClassWithOnlyUnitField, ClassWithUnitField}
 
 import java.time.LocalDateTime
@@ -150,7 +150,7 @@ class CaseClassDeserializerTest extends DeserializerTest {
 
   def propertyNamingStrategyMapper: ObjectMapper = new ObjectMapper() {
     registerModule(module)
-    setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+    setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
   }
 
   it should "honor the property naming strategy" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/CaseClassSerializerTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.scala.ser
 
 import com.fasterxml.jackson.annotation.JsonProperty.Access
 import com.fasterxml.jackson.annotation._
-import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategies}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 import scala.beans.BeanProperty
@@ -136,7 +136,7 @@ class CaseClassSerializerTest extends SerializerTest {
 
   def propertyNamingStrategyMapper = new ObjectMapper() {
     registerModule(module)
-    setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+    setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
   }
 
   it should "honor the property naming strategy" in {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/NamingStrategyTest.scala
@@ -2,7 +2,7 @@ package com.fasterxml.jackson
 package module.scala
 package ser
 
-import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategies}
 import org.scalatest.Outcome
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +21,7 @@ class NamingStrategyTest extends FixtureAnyFlatSpec with Matchers {
   protected def withFixture(test: OneArgTest): Outcome = {
     val mapper = new ObjectMapper()
     mapper.registerModule(DefaultScalaModule)
-    mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+    mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
     test(mapper)
   }
 


### PR DESCRIPTION
So, `PropertyNamingStrategy.SNAKE_CASE` (and other unsafe implementations) are being removed finally, as per:

https://github.com/FasterXML/jackson-databind/issues/4136

having been deprecated for years now. So this just changes tests to use `PropertyNamingStrategies.SNAKE_CASE` (replacement) instead.

