### PR TITLE
add config to allow override of deserializeNullCollectionsAsEmpty

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/scala/deser/ContainerDeserializerWithNullValueAsEmpty.java
+++ b/src/main/java/com/fasterxml/jackson/module/scala/deser/ContainerDeserializerWithNullValueAsEmpty.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.ContainerDeserializerBase;
+import com.fasterxml.jackson.module.scala.ScalaModule;
 
 /**
  * Internal Usage only
@@ -17,7 +18,8 @@ abstract class ContainerDeserializerWithNullValueAsEmpty<T> extends ContainerDes
 
     @Override
     public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-        if (ctxt.isEnabled(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)) {
+        if (!ScalaModule.shouldDeserializeNullCollectionsAsEmpty() ||
+                ctxt.isEnabled(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)) {
             return super.getNullValue(ctxt);
         } else {
             return (T) getEmptyValue(ctxt);

--- a/src/main/scala/com/fasterxml/jackson/module/scala/ScalaModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ScalaModule.scala
@@ -49,6 +49,17 @@ object ScalaModule {
     }
   }
 
+  private var deserializeNullCollectionsAsEmpty = true
+
   def builder(): Builder = new Builder()
+
+  /**
+   * @return whether the module should support deserializing null collections as empty (default: true)
+   */
+  def shouldDeserializeNullCollectionsAsEmpty(): Boolean = deserializeNullCollectionsAsEmpty
+
+  def deserializeNullCollectionsAsEmpty(asEmpty: Boolean): Unit = {
+    deserializeNullCollectionsAsEmpty = asEmpty
+  }
 }
 

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -217,7 +217,7 @@ class CaseClassDeserializerTest extends DeserializerTest {
     }
   }
 
-    it should "fail when deserializing null input for list if FAIL_ON_NULL_CREATOR_PROPERTIES enabled" in {
+  it should "fail when deserializing null input for list if FAIL_ON_NULL_CREATOR_PROPERTIES enabled" in {
     val input = """{}"""
     val mapper = newBuilder.enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES).build()
     intercept[com.fasterxml.jackson.databind.exc.MismatchedInputException] {

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseClassDeserializerTest.scala
@@ -206,7 +206,18 @@ class CaseClassDeserializerTest extends DeserializerTest {
     result.list shouldBe List.empty
   }
 
-  it should "fail when deserializing null input for list if FAIL_ON_NULL_CREATOR_PROPERTIES enabled" in {
+  it should "deserialize list as null if deserializeNullCollectionsAsEmpty config is false" in {
+    val input = """{}"""
+    try {
+      ScalaModule.deserializeNullCollectionsAsEmpty(false)
+      val result = deserialize(input, classOf[ListHolder[String]])
+      result.list shouldBe null
+    } finally {
+      ScalaModule.deserializeNullCollectionsAsEmpty(true) // reset to default
+    }
+  }
+
+    it should "fail when deserializing null input for list if FAIL_ON_NULL_CREATOR_PROPERTIES enabled" in {
     val input = """{}"""
     val mapper = newBuilder.enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES).build()
     intercept[com.fasterxml.jackson.databind.exc.MismatchedInputException] {
@@ -235,4 +246,14 @@ class CaseClassDeserializerTest extends DeserializerTest {
     }
   }
 
+  it should "deserialize map as null if deserializeNullCollectionsAsEmpty config is false" in {
+    val input = """{}"""
+    try {
+      ScalaModule.deserializeNullCollectionsAsEmpty(false)
+      val result = deserialize(input, classOf[MapHolder[Int, String]])
+      result.map shouldBe null
+    } finally {
+      ScalaModule.deserializeNullCollectionsAsEmpty(true) // reset to default
+    }
+  }
 }


### PR DESCRIPTION
* A simpler version of #743 
* jackson-module-scala 2.x has no mechanism to configure specific module instances - most code is based around singleton instances - 3.x has been refactored to allow this
* relates to #722 - this option allows people who unhappy with the new behaviour to get back to the old null based behaviour
  