### PR TITLE
Remove url apis

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/ClassTagExtensions.scala
+++ b/src/main/scala/tools/jackson/module/scala/ClassTagExtensions.scala
@@ -6,7 +6,6 @@ import tools.jackson.databind.`type`.{MapLikeType, TypeFactory}
 import tools.jackson.databind.json.JsonMapper
 
 import java.io.{File, InputStream, Reader}
-import java.net.URL
 import scala.collection.immutable.IntMap
 import scala.collection.{immutable, mutable}
 import scala.reflect.ClassTag
@@ -112,10 +111,6 @@ trait ClassTagExtensions {
     readValue(src, constructType[T])
   }
 
-  def readValue[T: JavaTypeable](src: URL): T = {
-    readValue(src, constructType[T])
-  }
-
   def readValue[T: JavaTypeable](content: String): T = {
     readValue(content, constructType[T])
   }
@@ -137,10 +132,6 @@ trait ClassTagExtensions {
   }
 
   def updateValue[T: JavaTypeable](valueToUpdate: T, src: File): T = {
-    objectReaderFor(valueToUpdate).readValue(src)
-  }
-
-  def updateValue[T: JavaTypeable](valueToUpdate: T, src: URL): T = {
     objectReaderFor(valueToUpdate).readValue(src)
   }
 

--- a/src/test/scala/tools/jackson/module/scala/ClassTagExtensionsTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/ClassTagExtensionsTest.scala
@@ -97,13 +97,6 @@ class ClassTagExtensionsTest extends JacksonTest {
     }
   }
 
-  it should "read value from URL" in {
-    withFile(genericJson) { file =>
-      val result = mapper.readValue[GenericTestClass[Int]](file.toURI.toURL)
-      result should equal(genericInt)
-    }
-  }
-
   it should "read value from string" in {
     val result = mapper.readValue[GenericTestClass[Int]](genericJson)
     result should equal(genericInt)
@@ -230,13 +223,6 @@ class ClassTagExtensionsTest extends JacksonTest {
   it should "update value from file" in {
     withFile(toplevelArrayJson) { file =>
       val result = mapper.updateValue(List.empty[GenericTestClass[Int]], file)
-      result should equal(listGenericInt)
-    }
-  }
-
-  it should "update value from URL" in {
-    withFile(toplevelArrayJson) { file =>
-      val result = mapper.updateValue(List.empty[GenericTestClass[Int]], file.toURI.toURL)
       result should equal(listGenericInt)
     }
   }


### PR DESCRIPTION
* see #758 
* users can pass InputStreams instead of URLs
* they can worry about connection pooling and closing the URL connections themselves
