### PR TITLE
support parameterized cases in Scala 3 enums

### DIFF
--- a/src/main/scala-3/tools/jackson/module/scala/EnumModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/EnumModule.scala
@@ -3,6 +3,7 @@ package tools.jackson.module.scala
 import tools.jackson.databind.JacksonModule.SetupContext
 import tools.jackson.module.scala.deser.EnumDeserializerModule
 import tools.jackson.module.scala.ser.EnumSerializerModule
+import tools.jackson.module.scala.util.Scala3EnumInfo
 
 trait EnumModule extends EnumSerializerModule with EnumDeserializerModule {
   override def getModuleName: String = "EnumModule"
@@ -13,4 +14,43 @@ trait EnumModule extends EnumSerializerModule with EnumDeserializerModule {
   }
 }
 
-object EnumModule extends EnumModule
+object EnumModule extends EnumModule {
+
+  /**
+   * Replaces the [[LookupCacheFactory]] used for the cache of Scala 3 enum case tables. The default
+   * factory uses [[tools.jackson.databind.util.SimpleLookupCache]].
+   * <p>
+   * Note that this clears the existing cache entries. The cache is only a memo of what can be
+   * derived reflectively from an enum class, so clearing it affects performance but not behaviour.
+   * </p>
+   *
+   * @param lookupCacheFactory new factory
+   * @see [[setEnumInfoCacheSize]]
+   * @since 3.3.0
+   */
+  def setLookupCacheFactory(lookupCacheFactory: LookupCacheFactory): Unit =
+    Scala3EnumInfo.setLookupCacheFactory(lookupCacheFactory)
+
+  /**
+   * Resize the cache of Scala 3 enum case tables. The default size is 1000.
+   * <p>
+   * The cache is bounded so that enum classes loaded by a short lived classloader are not retained
+   * indefinitely. Entries are keyed by class, and an evicted entry is rebuilt on the next lookup.
+   * </p>
+   * <p>
+   * Note that this clears the existing cache entries.
+   * </p>
+   *
+   * @param size new size for the cache
+   * @see [[setLookupCacheFactory]]
+   * @since 3.3.0
+   */
+  def setEnumInfoCacheSize(size: Int): Unit = Scala3EnumInfo.setCacheSize(size)
+
+  /**
+   * Empties the cache of Scala 3 enum case tables.
+   *
+   * @since 3.3.0
+   */
+  def clearEnumInfoCache(): Unit = Scala3EnumInfo.clearCache()
+}

--- a/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
@@ -1,12 +1,13 @@
 package tools.jackson.module.scala.deser
 
-import tools.jackson.core.JsonParser
+import tools.jackson.core.{JsonParser, JsonToken}
 import tools.jackson.databind.deser.{Deserializers, KeyDeserializers}
 import tools.jackson.databind.deser.std.StdDeserializer
 import tools.jackson.databind._
 import tools.jackson.databind.JacksonModule.SetupContext
 import tools.jackson.module.scala.{JacksonModule, ScalaModule}
 import tools.jackson.module.scala.JacksonModule.InitializerBuilder
+import tools.jackson.module.scala.util.Scala3EnumInfo
 
 import java.lang.reflect.InvocationTargetException
 import scala.reflect.Enum
@@ -67,6 +68,11 @@ private[scala] object EnumDeserializerShared {
       matched
     }
   }
+
+  // Scala 3 enums that mix parameterized and simple cases have neither valueOf nor a usable
+  // fromOrdinal, so they are handled from the reflective case table instead.
+  def taggedSumInfo(clz: Class[_]): Option[Scala3EnumInfo.Info] =
+    Scala3EnumInfo.infoFor(clz).filter(_.isTaggedSum)
 }
 
 private case class EnumDeserializer[T <: Enum](clazz: Class[T]) extends StdDeserializer[T](clazz) {
@@ -82,6 +88,53 @@ private case class EnumDeserializer[T <: Enum](clazz: Class[T]) extends StdDeser
   }
 }
 
+/**
+ * Deserializer for Scala 3 enums that have parameterized cases. Simple cases are read from their
+ * name (as written by the serializer), parameterized cases from a JSON object tagged with a
+ * `type` property naming the case.
+ */
+private case class Scala3EnumSumDeserializer[T <: Enum](info: Scala3EnumInfo.Info)
+  extends StdDeserializer[T](info.rootClass) {
+
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): T = {
+    val value = p.currentToken() match {
+      case JsonToken.START_OBJECT => fromObject(p, ctxt)
+      case _ => fromName(p.getValueAsString)
+    }
+    value.asInstanceOf[T]
+  }
+
+  private def fromName(name: String): AnyRef = {
+    if (name == null) failed(name)
+    else info.caseForName(name).flatMap(_.singleton).getOrElse(failed(name))
+  }
+
+  private def fromObject(p: JsonParser, ctxt: DeserializationContext): AnyRef = {
+    val buffer = ctxt.bufferForInputBuffering(p)
+    buffer.writeStartObject()
+    var typeId: String = None.orNull
+    while (p.nextToken() != JsonToken.END_OBJECT) {
+      val name = p.currentName()
+      p.nextToken()
+      if (typeId == null && name == Scala3EnumInfo.TypePropertyName) {
+        typeId = p.getValueAsString
+      } else {
+        buffer.writeName(name)
+        buffer.copyCurrentStructure(p)
+      }
+    }
+    buffer.writeEndObject()
+    val enumCase = Option(typeId).flatMap(info.caseForName).getOrElse(failed(typeId))
+    enumCase.singleton match {
+      case Some(singleton) => singleton
+      case None => ctxt.readValue(buffer.asParserOnFirstToken(ctxt), enumCase.clazz.asInstanceOf[Class[AnyRef]])
+    }
+  }
+
+  private def failed(name: String): Nothing =
+    throw new IllegalArgumentException(s"Failed to create ${info.rootClass.getName} instance for $name")
+}
+
 private case class EnumKeyDeserializer[T <: Enum](clazz: Class[T]) extends KeyDeserializer {
   override def deserializeKey(key: String, ctxt: DeserializationContext): AnyRef = {
     val result = Try {
@@ -95,13 +148,21 @@ private case class EnumKeyDeserializer[T <: Enum](clazz: Class[T]) extends KeyDe
 
 private class EnumDeserializerResolver(config: ScalaModule.Config) extends Deserializers.Base {
   override def findBeanDeserializer(javaType: JavaType, config: DeserializationConfig, beanDesc: BeanDescription.Supplier): ValueDeserializer[Enum] =
-    if (hasDeserializerFor(config, javaType.getRawClass))
-      EnumDeserializer(javaType.getRawClass.asInstanceOf[Class[Enum]])
-    else None.orNull
+    deserializerFor(javaType.getRawClass).orNull
 
   override def hasDeserializerFor(deserializationConfig: DeserializationConfig, valueType: Class[_]): Boolean =
-    EnumDeserializerShared.EnumClass.isAssignableFrom(valueType)
-      && EnumDeserializerShared.canFindByOrdinal(valueType)
+    deserializerFor(valueType).isDefined
+
+  private def deserializerFor(rawClass: Class[_]): Option[ValueDeserializer[Enum]] = {
+    if (!EnumDeserializerShared.EnumClass.isAssignableFrom(rawClass)) None
+    else EnumDeserializerShared.taggedSumInfo(rawClass) match {
+      // the generated case classes are left to the standard bean deserializer
+      case Some(info) => if (info.rootClass == rawClass) Some(Scala3EnumSumDeserializer(info)) else None
+      case None =>
+        if (EnumDeserializerShared.canFindByOrdinal(rawClass)) Some(EnumDeserializer(rawClass.asInstanceOf[Class[Enum]]))
+        else None
+    }
+  }
 }
 
 private class EnumKeyDeserializerResolver(config: ScalaModule.Config) extends KeyDeserializers {

--- a/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
@@ -2,15 +2,15 @@ package tools.jackson.module.scala.ser
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import tools.jackson.core.JsonGenerator
-import tools.jackson.databind.ser.Serializers
+import tools.jackson.databind.ser.{Serializers, ValueSerializerModifier}
 import tools.jackson.databind._
-import tools.jackson.databind.deser.KeyDeserializers
 import tools.jackson.databind.JacksonModule.SetupContext
+import tools.jackson.databind.util.NameTransformer
 import tools.jackson.module.scala.{JacksonModule, ScalaModule}
 import tools.jackson.module.scala.JacksonModule.InitializerBuilder
 import tools.jackson.module.scala.deser.EnumDeserializerShared
+import tools.jackson.module.scala.util.Scala3EnumInfo
 
-import scala.languageFeature.postfixOps
 import scala.reflect.Enum
 
 private object EnumSerializer extends ValueSerializer[Enum] {
@@ -24,19 +24,74 @@ private object EnumKeySerializer extends ValueSerializer[Enum] {
     jgen.writeName(value.toString)
 }
 
+/**
+ * Serializer bound to the declared type of a Scala 3 enum that has parameterized cases. Simple
+ * cases are written as their name; parameterized cases are delegated to the serializer of the
+ * generated case class, which [[Scala3EnumCaseSerializer]] has tagged with a `type` property.
+ */
+private case class Scala3EnumSumSerializer(info: Scala3EnumInfo.Info) extends ValueSerializer[Enum] {
+  override def serialize(value: Enum, jgen: JsonGenerator, serializationContext: SerializationContext): Unit = {
+    if (info.parameterizedCaseFor(value.getClass).isDefined) {
+      serializationContext.findValueSerializer(value.getClass).serialize(value, jgen, serializationContext)
+    } else {
+      jgen.writeString(value.toString)
+    }
+  }
+}
+
+/**
+ * Wraps the bean serializer of a parameterized Scala 3 enum case so that the case name is written
+ * as a `type` property, making the value round-trippable.
+ */
+private class Scala3EnumCaseSerializer(typeName: String, delegate: ValueSerializer[AnyRef])
+  extends ValueSerializer[AnyRef] {
+
+  private lazy val unwrapped = delegate.unwrappingSerializer(NameTransformer.NOP)
+
+  override def resolve(serializationContext: SerializationContext): Unit = delegate.resolve(serializationContext)
+
+  override def createContextual(serializationContext: SerializationContext, property: BeanProperty): ValueSerializer[_] = {
+    val contextual = delegate.createContextual(serializationContext, property)
+    if (contextual eq delegate) this
+    else new Scala3EnumCaseSerializer(typeName, contextual.asInstanceOf[ValueSerializer[AnyRef]])
+  }
+
+  override def serialize(value: AnyRef, jgen: JsonGenerator, serializationContext: SerializationContext): Unit = {
+    jgen.writeStartObject(value)
+    jgen.writeStringProperty(Scala3EnumInfo.TypePropertyName, typeName)
+    unwrapped.serialize(value, jgen, serializationContext)
+    jgen.writeEndObject()
+  }
+}
+
 private class EnumSerializerResolver(config: ScalaModule.Config) extends Serializers.Base {
   override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription.Supplier,
-                              formatOverrides: JsonFormat.Value): ValueSerializer[Enum] =
-    if (EnumDeserializerShared.EnumClass.isAssignableFrom(javaType.getRawClass)
-        && EnumDeserializerShared.canFindByOrdinal(javaType.getRawClass))
-      EnumSerializer
-    else None.orNull
+                              formatOverrides: JsonFormat.Value): ValueSerializer[Enum] = {
+    val rawClass = javaType.getRawClass
+    if (!EnumDeserializerShared.EnumClass.isAssignableFrom(rawClass)) None.orNull
+    else EnumDeserializerShared.taggedSumInfo(rawClass) match {
+      // the generated case classes are serialized as beans, tagged by EnumSerializerModifier
+      case Some(info) => if (info.parameterizedCaseFor(rawClass).isDefined) None.orNull else Scala3EnumSumSerializer(info)
+      case None => if (EnumDeserializerShared.canFindByOrdinal(rawClass)) EnumSerializer else None.orNull
+    }
+  }
+}
+
+private class EnumSerializerModifier(config: ScalaModule.Config) extends ValueSerializerModifier {
+  override def modifySerializer(config: SerializationConfig, beanDesc: BeanDescription.Supplier,
+                                serializer: ValueSerializer[_]): ValueSerializer[_] = {
+    val rawClass = beanDesc.getBeanClass
+    EnumDeserializerShared.taggedSumInfo(rawClass).flatMap(_.parameterizedCaseFor(rawClass)) match {
+      case Some(enumCase) => new Scala3EnumCaseSerializer(enumCase.name, serializer.asInstanceOf[ValueSerializer[AnyRef]])
+      case None => serializer
+    }
+  }
 }
 
 private class EnumKeySerializerResolver(config: ScalaModule.Config) extends Serializers.Base {
   override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription.Supplier,
                               formatOverrides: JsonFormat.Value): ValueSerializer[Enum] =
-    if (EnumDeserializerShared.EnumClass isAssignableFrom javaType.getRawClass)
+    if (EnumDeserializerShared.EnumClass.isAssignableFrom(javaType.getRawClass))
       EnumKeySerializer
     else None.orNull
 }
@@ -47,6 +102,7 @@ trait EnumSerializerModule extends JacksonModule {
   override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
     val builder = new InitializerBuilder()
     builder += new EnumSerializerResolver(config)
+    builder += new EnumSerializerModifier(config)
     builder.addKeySerializers(new EnumKeySerializerResolver(config))
     builder.build()
   }

--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -1,0 +1,105 @@
+package tools.jackson.module.scala.util
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentHashMap
+import scala.deriving.Mirror
+import scala.util.Try
+
+/**
+ * Runtime view of the cases of a Scala 3 `enum`.
+ *
+ * Apache Fory builds the same table at compile time with a macro (`ScalaJsonCodecMacros` produces
+ * the case classes, case names and singleton instances that `DerivedScalaJsonCodec` dispatches on).
+ * jackson-module-scala only ever sees a `Class[_]`, so the table is recovered reflectively instead:
+ * the compiler emits one public static field per case on the enum companion, holding either the
+ * singleton instance (simple case) or the companion object of the generated case class
+ * (parameterized case).
+ */
+private[scala] object Scala3EnumInfo {
+
+  /** Name of the JSON property used to tag a parameterized enum case. */
+  val TypePropertyName = "type"
+
+  private val ModuleFieldName = "MODULE$"
+  private val EnumClass = classOf[scala.reflect.Enum]
+
+  final case class EnumCase(name: String, clazz: Class[_], singleton: Option[AnyRef])
+
+  final class Info(val rootClass: Class[_], val cases: Seq[EnumCase]) {
+    private val casesByName: Map[String, EnumCase] = cases.map(c => c.name -> c).toMap
+    // singleton cases of one enum all share a single anonymous class, so only parameterized
+    // cases can be looked up by class
+    private val casesByClass: Map[Class[_], EnumCase] =
+      cases.collect { case c if c.singleton.isEmpty => c.clazz -> c }.toMap
+
+    val hasParameterizedCases: Boolean = casesByClass.nonEmpty
+
+    /**
+     * True if this enum should be handled as a tagged sum. Enums that already carry
+     * `@JsonTypeInfo` are left to the standard Jackson polymorphic handling.
+     */
+    val isTaggedSum: Boolean =
+      hasParameterizedCases && rootClass.getAnnotation(classOf[JsonTypeInfo]) == null
+
+    def caseForName(name: String): Option[EnumCase] = casesByName.get(name)
+    def parameterizedCaseFor(clazz: Class[_]): Option[EnumCase] = casesByClass.get(clazz)
+  }
+
+  private val cache = new ConcurrentHashMap[Class[_], Option[Info]]()
+
+  /**
+   * Returns the case table of the Scala 3 enum that `clazz` belongs to - `clazz` may be the enum
+   * itself, one of its parameterized case classes, or the anonymous class used for its simple cases.
+   */
+  def infoFor(clazz: Class[_]): Option[Info] = {
+    if (clazz == null || !EnumClass.isAssignableFrom(clazz)) None
+    else cache.computeIfAbsent(clazz, _ => findInfo(clazz))
+  }
+
+  private def findInfo(clazz: Class[_]): Option[Info] = {
+    var current: Class[_] = clazz
+    var result: Option[Info] = None
+    while (result.isEmpty && current != null && EnumClass.isAssignableFrom(current)) {
+      result = buildInfo(current)
+      current = current.getSuperclass
+    }
+    result
+  }
+
+  private def buildInfo(rootClass: Class[_]): Option[Info] = {
+    companionOf(rootClass).filter(_.isInstanceOf[Mirror.Sum]).flatMap { companion =>
+      val cases = companion.getClass.getDeclaredFields.toSeq.filter { field =>
+        val modifiers = field.getModifiers
+        Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers) &&
+          field.getName != ModuleFieldName && !field.getName.startsWith("$")
+      }.flatMap { field =>
+        val name = field.getName
+        if (rootClass.isAssignableFrom(field.getType)) {
+          // simple case - the field holds the singleton instance
+          Option(field.get(None.orNull)).map { value =>
+            EnumCase(name, value.getClass, Some(value.asInstanceOf[AnyRef]))
+          }
+        } else if (field.getType.getName.endsWith("$")) {
+          // parameterized case - the field holds the companion of the generated case class
+          val caseClassName = field.getType.getName.dropRight(1)
+          Try(Class.forName(caseClassName, false, loaderFor(rootClass))).toOption
+            .filter(rootClass.isAssignableFrom)
+            .map(caseClass => EnumCase(name, caseClass, None))
+        } else None
+      }
+      if (cases.isEmpty) None else Some(new Info(rootClass, cases))
+    }
+  }
+
+  private def companionOf(clazz: Class[_]): Option[AnyRef] = {
+    Try {
+      val companionClass = Class.forName(clazz.getName + "$", true, loaderFor(clazz))
+      companionClass.getField(ModuleFieldName).get(None.orNull)
+    }.toOption
+  }
+
+  private def loaderFor(clazz: Class[_]): ClassLoader =
+    Option(clazz.getClassLoader).getOrElse(ClassLoader.getSystemClassLoader)
+}

--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -1,9 +1,10 @@
 package tools.jackson.module.scala.util
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import tools.jackson.databind.util.LookupCache
+import tools.jackson.module.scala.DefaultLookupCacheFactory
 
 import java.lang.reflect.Modifier
-import java.util.concurrent.ConcurrentHashMap
 import scala.deriving.Mirror
 import scala.util.Try
 
@@ -47,7 +48,12 @@ private[scala] object Scala3EnumInfo {
     def parameterizedCaseFor(clazz: Class[_]): Option[EnumCase] = casesByClass.get(clazz)
   }
 
-  private val cache = new ConcurrentHashMap[Class[_], Option[Info]]()
+  // Bounded so that classes loaded by a child classloader (hot redeploy, OSGi, script engines) are
+  // not retained indefinitely by this object. Keyed by Class rather than by class name because the
+  // cached Info holds Class instances - two same-named enums from different classloaders must not
+  // share an entry.
+  private val cache: LookupCache[Class[_], Option[Info]] =
+    DefaultLookupCacheFactory.createLookupCache(16, 1000)
 
   /**
    * Returns the case table of the Scala 3 enum that `clazz` belongs to - `clazz` may be the enum
@@ -55,7 +61,12 @@ private[scala] object Scala3EnumInfo {
    */
   def infoFor(clazz: Class[_]): Option[Info] = {
     if (clazz == null || !EnumClass.isAssignableFrom(clazz)) None
-    else cache.computeIfAbsent(clazz, _ => findInfo(clazz))
+    else Option(cache.get(clazz)) match {
+      case Some(info) => info
+      case _ =>
+        val info = findInfo(clazz)
+        Option(cache.putIfAbsent(clazz, info)).getOrElse(info)
+    }
   }
 
   private def findInfo(clazz: Class[_]): Option[Info] = {

--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -2,7 +2,7 @@ package tools.jackson.module.scala.util
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import tools.jackson.databind.util.LookupCache
-import tools.jackson.module.scala.DefaultLookupCacheFactory
+import tools.jackson.module.scala.{DefaultLookupCacheFactory, LookupCacheFactory}
 
 import java.lang.reflect.Modifier
 import scala.deriving.Mirror
@@ -48,12 +48,15 @@ private[scala] object Scala3EnumInfo {
     def parameterizedCaseFor(clazz: Class[_]): Option[EnumCase] = casesByClass.get(clazz)
   }
 
+  private var _lookupCacheFactory: LookupCacheFactory = DefaultLookupCacheFactory
+  private var _cacheSize: Int = 1000
+
   // Bounded so that classes loaded by a child classloader (hot redeploy, OSGi, script engines) are
   // not retained indefinitely by this object. Keyed by Class rather than by class name because the
   // cached Info holds Class instances - two same-named enums from different classloaders must not
-  // share an entry.
-  private val cache: LookupCache[Class[_], Option[Info]] =
-    DefaultLookupCacheFactory.createLookupCache(16, 1000)
+  // share an entry. The cache is a pure memo - an evicted entry is rebuilt on the next lookup.
+  @volatile private var _cache: LookupCache[Class[_], Option[Info]] =
+    _lookupCacheFactory.createLookupCache(16, _cacheSize)
 
   /**
    * Returns the case table of the Scala 3 enum that `clazz` belongs to - `clazz` may be the enum
@@ -61,12 +64,32 @@ private[scala] object Scala3EnumInfo {
    */
   def infoFor(clazz: Class[_]): Option[Info] = {
     if (clazz == null || !EnumClass.isAssignableFrom(clazz)) None
-    else Option(cache.get(clazz)) match {
-      case Some(info) => info
-      case _ =>
-        val info = findInfo(clazz)
-        Option(cache.putIfAbsent(clazz, info)).getOrElse(info)
+    else {
+      val cache = _cache
+      Option(cache.get(clazz)) match {
+        case Some(info) => info
+        case _ =>
+          val info = findInfo(clazz)
+          Option(cache.putIfAbsent(clazz, info)).getOrElse(info)
+      }
     }
+  }
+
+  def setLookupCacheFactory(lookupCacheFactory: LookupCacheFactory): Unit = {
+    _lookupCacheFactory = lookupCacheFactory
+    recreateCache()
+  }
+
+  def setCacheSize(size: Int): Unit = {
+    _cacheSize = size
+    recreateCache()
+  }
+
+  def clearCache(): Unit = _cache.clear()
+
+  private def recreateCache(): Unit = {
+    _cache.clear()
+    _cache = _lookupCacheFactory.createLookupCache(16, _cacheSize)
   }
 
   private def findInfo(clazz: Class[_]): Option[Info] = {

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumDeserializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumDeserializerSpec.scala
@@ -49,19 +49,19 @@ class EnumDeserializerSpec extends AnyWordSpec with Matchers {
       map(ColorEnum.Red) shouldEqual "red"
     }
     // see https://github.com/FasterXML/jackson-module-scala/issues/831
-    "deserialize ResultEnum.Ok" ignore {
+    "deserialize ResultEnum.Ok" in {
       val instance = Result(ResultEnum.Ok("my-result"))
       val json = mapper.writeValueAsString(instance)
       mapper.readValue(json, classOf[Result]) shouldEqual instance
     }
     // see https://github.com/FasterXML/jackson-module-scala/issues/831
-    "deserialize ResultEnum.Error" ignore {
+    "deserialize ResultEnum.Error" in {
       val instance = Result(ResultEnum.Error(123))
       val json = mapper.writeValueAsString(instance)
       mapper.readValue(json, classOf[Result]) shouldEqual instance
     }
     // see https://github.com/FasterXML/jackson-module-scala/issues/831
-    "deserialize ResultEnum.Pending" ignore {
+    "deserialize ResultEnum.Pending" in {
       val instance = Result(ResultEnum.Pending)
       val json = mapper.writeValueAsString(instance)
       mapper.readValue(json, classOf[Result]) shouldEqual instance

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumInfoCacheSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumInfoCacheSpec.scala
@@ -1,0 +1,54 @@
+package tools.jackson.module.scala.`enum`
+
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.{DefaultLookupCacheFactory, DefaultScalaModule, EnumModule}
+import tools.jackson.module.scala.`enum`.adt.{Color, ColorSet}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * The case tables that back Scala 3 enum support are cached, and that cache is bounded. An evicted
+ * entry has to be rebuilt on demand, so eviction must not be observable in what gets written or read.
+ */
+class EnumInfoCacheSpec extends AnyWordSpec with Matchers {
+
+  private val DefaultCacheSize = 1000
+
+  // a mapper caches the serializers and deserializers it has resolved, and those hold onto the case
+  // table they were built with - a new mapper is needed to force the table to be looked up again
+  private def newMapper() = JsonMapper.builder().addModule(DefaultScalaModule).build()
+
+  "EnumModule" should {
+    "rebuild a case table that has been evicted" in {
+      val instance = Result(ResultEnum.Ok("my-result"))
+      val json = newMapper().writeValueAsString(instance)
+      EnumModule.clearEnumInfoCache()
+      newMapper().readValue(json, classOf[Result]) shouldEqual instance
+    }
+    "rebuild a case table for a simple case that has been evicted" in {
+      val json = newMapper().writeValueAsString(Result(ResultEnum.Pending))
+      EnumModule.clearEnumInfoCache()
+      // simple cases are read back from the enum companion, so the singleton is preserved
+      newMapper().readValue(json, classOf[Result]).result should be theSameInstanceAs ResultEnum.Pending
+    }
+    "handle a cache too small to hold every enum" in {
+      try {
+        EnumModule.setEnumInfoCacheSize(1)
+        val result = Result(ResultEnum.Error(123))
+        val colors = ColorSet(Set(Color.Red, Color.Mix(0x4488FF)))
+        // each enum touched here evicts the one before it
+        newMapper().readValue(newMapper().writeValueAsString(result), classOf[Result]) shouldEqual result
+        newMapper().readValue(newMapper().writeValueAsString(colors), classOf[ColorSet]) shouldEqual colors
+        newMapper().readValue(newMapper().writeValueAsString(result), classOf[Result]) shouldEqual result
+      } finally {
+        EnumModule.setEnumInfoCacheSize(DefaultCacheSize)
+      }
+    }
+    "keep working after the lookup cache factory is replaced" in {
+      val instance = Result(ResultEnum.Ok("my-result"))
+      val json = newMapper().writeValueAsString(instance)
+      EnumModule.setLookupCacheFactory(DefaultLookupCacheFactory)
+      newMapper().readValue(json, classOf[Result]) shouldEqual instance
+    }
+  }
+}

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumSerializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumSerializerSpec.scala
@@ -36,18 +36,16 @@ class EnumSerializerSpec extends AnyWordSpec with Matchers {
     "serialize Enum as Map Key" in {
       mapper.writeValueAsString(Map(ColorEnum.Green -> "green")) shouldEqual s"""{"Green":"green"}"""
     }
-    "serialize ResultEnum.Ok" ignore {
-      // not a great serialization and should be changed to write a JSON object with a type marker
-      // see https://github.com/FasterXML/jackson-module-scala/issues/831
-      mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) shouldEqual s"""{"result":"Ok(my-result)"}"""
+    // parameterized cases are written as JSON objects tagged with a type marker
+    // see https://github.com/FasterXML/jackson-module-scala/issues/831
+    "serialize ResultEnum.Ok" in {
+      mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) shouldEqual s"""{"result":{"type":"Ok","value":"my-result"}}"""
     }
-    "serialize ResultEnum.Error" ignore {
-      // not a great serialization and should be changed to write a JSON object with a type marker
-      // see https://github.com/FasterXML/jackson-module-scala/issues/831
-      mapper.writeValueAsString(Result(ResultEnum.Error(123))) shouldEqual s"""{"result":"Error(123)"}"""
+    "serialize ResultEnum.Error" in {
+      mapper.writeValueAsString(Result(ResultEnum.Error(123))) shouldEqual s"""{"result":{"type":"Error","code":123}}"""
     }
-    "serialize ResultEnum.Pending" ignore {
-      // broken - see https://github.com/FasterXML/jackson-module-scala/issues/831
+    // simple cases of the same enum keep their plain name
+    "serialize ResultEnum.Pending" in {
       mapper.writeValueAsString(Result(ResultEnum.Pending)) shouldEqual s"""{"result":"Pending"}"""
     }
     "serialize ShapeEnumAnnotated.Circle" in {

--- a/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtDeserializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtDeserializerSpec.scala
@@ -19,8 +19,12 @@ class AdtDeserializerSpec extends AnyWordSpec with Matchers {
         mapper.readValue(json, classOf[Color])
       }
     }
+    "deserialize Color.Mix" in {
+      val json = mapper.writeValueAsString(Color.Mix(0x4488FF))
+      mapper.readValue(json, classOf[Color]) shouldEqual Color.Mix(0x4488FF)
+    }
     "deserialize ColorSet" in {
-      val colors = ColorSet(Set(Color.Red, Color.Green))
+      val colors = ColorSet(Set(Color.Red, Color.Green, Color.Mix(0x4488FF)))
       val json = mapper.writeValueAsString(colors)
       mapper.readValue(json, classOf[ColorSet]) shouldEqual colors
     }

--- a/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtSerializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtSerializerSpec.scala
@@ -12,8 +12,10 @@ class AdtSerializerSpec extends AnyWordSpec with Matchers {
     "serialize Color ADT" in {
       mapper.writeValueAsString(Color.Red) shouldEqual (s""""${Color.Red}"""")
     }
+    // the parameterized case is written as a JSON object tagged with a type marker
+    // see https://github.com/FasterXML/jackson-module-scala/issues/831
     "serialize Color.Mix" in {
-      mapper.writeValueAsString(Color.Mix(0x4488FF)) shouldEqual (s""""Mix(4491519)"""")
+      mapper.writeValueAsString(Color.Mix(0x4488FF)) shouldEqual (s"""{"type":"Mix","mix":4491519,"rgb":4491519}""")
     }
     "serialize ColorSet" in {
       val json = mapper.writeValueAsString(ColorSet(Set(Color.Red, Color.Green)))


### PR DESCRIPTION
Fixes #831 — re-enables the six ignored `ResultEnum` tests in `EnumSerializerSpec`/`EnumDeserializerSpec`.

### Problem

A Scala 3 enum with parameterized cases has neither a usable `valueOf` nor a usable `fromOrdinal`, so `EnumSerializer`/`EnumDeserializer` fell back to `toString` and produced output that could not be read back. Mixing parameterized and simple cases broke the simple cases too.

### Approach

Added `Scala3EnumInfo`, a reflective case table for a Scala 3 enum. The compiler emits one public static field per case on the enum companion (which implements `Mirror.Sum`): simple cases hold the singleton instance, parameterized cases hold the companion of the generated case class (`ResultEnum$Ok$` → `ResultEnum$Ok`).

This is the same model [Apache Fory](https://github.com/apache/fory/blob/main/scala/fory-json-scala/src/main/scala-3/org/apache/fory/json/scala/internal/ScalaJsonCodecMacros.scala) builds in `fory-json-scala` — their macro emits `(caseClasses, caseNames, singletons)` for `DerivedScalaJsonCodec` to dispatch on. A macro isn't usable here: it needs `derives ScalaJsonCodec` at the declaration site, whereas this module only ever sees a `java.lang.Class` at runtime. So the table is recovered by reflection instead.

- **Parameterized cases** are written as a JSON object tagged with a `type` property naming the case, and read back by delegating to the standard bean deserializer for that case class. The tag is added by a `ValueSerializerModifier` wrapping the bean serializer (via `unwrappingSerializer(NameTransformer.NOP)`), which avoids the resolver recursion you'd hit delegating through `findValueSerializer`.
- **Simple cases** keep writing their plain name. All simple cases of one enum share a single anonymous class, so they can't be keyed by class the way Jackson's `Id.NAME` handling requires — which is why this doesn't go through the stock `@JsonTypeInfo` machinery.
- Enums that already carry `@JsonTypeInfo` (e.g. `ShapeEnumAnnotated`) are excluded and keep using the standard polymorphic handling.

```
{"result":{"type":"Ok","value":"my-result"}}
{"result":{"type":"Error","code":123}}
{"result":"Pending"}
```

### Behaviour change

`adt.Color` (three simple cases plus `Mix(mix: Int)`) also qualifies, so `Color.Mix(0x4488FF)` now serializes as `{"type":"Mix","mix":4491519,"rgb":4491519}` rather than `"Mix(4491519)"`. The old form could not be deserialized at all; `AdtSerializerSpec` is updated and round-trip coverage added. `Color.Red`/`Green` are unaffected and still serialize as `"Red"`/`"Green"`.

### Testing

`sbt ++3.3.8 test` — 615 passed, 0 ignored under `src/test/scala-3`. `sbt test mimaReportBinaryIssues` on 2.13 — 578 passed, mima clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263NLDeEasXcvWEYEvLa9u
