### PR TITLE
tag Scala 3 enum cases with @type rather than type

### DIFF
--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -20,8 +20,12 @@ import scala.util.Try
  */
 private[scala] object Scala3EnumInfo {
 
-  /** Name of the JSON property used to tag a parameterized enum case. */
-  val TypePropertyName = "type"
+  /**
+   * Name of the JSON property used to tag a parameterized enum case. `@type` rather than `type` so
+   * that it cannot clash with a field of the case itself - it is also what Jackson uses by default
+   * for `JsonTypeInfo.Id.NAME`.
+   */
+  val TypePropertyName = "@type"
 
   private val ModuleFieldName = "MODULE$"
   private val EnumClass = classOf[scala.reflect.Enum]

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumDeserializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumDeserializerSpec.scala
@@ -66,6 +66,16 @@ class EnumDeserializerSpec extends AnyWordSpec with Matchers {
       val json = mapper.writeValueAsString(instance)
       mapper.readValue(json, classOf[Result]) shouldEqual instance
     }
+    "deserialize a case that has its own type field" in {
+      val instance = TypeFieldHolder(TypeFieldEnum.Typed("custom"))
+      val json = mapper.writeValueAsString(instance)
+      mapper.readValue(json, classOf[TypeFieldHolder]) shouldEqual instance
+    }
+    "deserialize a simple case of an enum that has a type field elsewhere" in {
+      val instance = TypeFieldHolder(TypeFieldEnum.Untyped)
+      val json = mapper.writeValueAsString(instance)
+      mapper.readValue(json, classOf[TypeFieldHolder]) shouldEqual instance
+    }
     "deserialize ShapeEnumAnnotated.Circle" in {
       val instance = ShapeEnumAnnotatedHolder(ShapeEnumAnnotated.Circle(1.5))
       val json = mapper.writeValueAsString(instance)

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumSerializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumSerializerSpec.scala
@@ -39,14 +39,19 @@ class EnumSerializerSpec extends AnyWordSpec with Matchers {
     // parameterized cases are written as JSON objects tagged with a type marker
     // see https://github.com/FasterXML/jackson-module-scala/issues/831
     "serialize ResultEnum.Ok" in {
-      mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) shouldEqual s"""{"result":{"type":"Ok","value":"my-result"}}"""
+      mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) shouldEqual s"""{"result":{"@type":"Ok","value":"my-result"}}"""
     }
     "serialize ResultEnum.Error" in {
-      mapper.writeValueAsString(Result(ResultEnum.Error(123))) shouldEqual s"""{"result":{"type":"Error","code":123}}"""
+      mapper.writeValueAsString(Result(ResultEnum.Error(123))) shouldEqual s"""{"result":{"@type":"Error","code":123}}"""
     }
     // simple cases of the same enum keep their plain name
     "serialize ResultEnum.Pending" in {
       mapper.writeValueAsString(Result(ResultEnum.Pending)) shouldEqual s"""{"result":"Pending"}"""
+    }
+    // the tag is `@type` so that it cannot clash with a field of the case itself
+    "serialize a case that has its own type field" in {
+      mapper.writeValueAsString(TypeFieldHolder(TypeFieldEnum.Typed("custom"))) shouldEqual
+        s"""{"value":{"@type":"Typed","type":"custom"}}"""
     }
     "serialize ShapeEnumAnnotated.Circle" in {
       mapper.writeValueAsString(ShapeEnumAnnotatedHolder(ShapeEnumAnnotated.Circle(1.5))) shouldEqual

--- a/src/test/scala-3/tools/jackson/module/scala/enum/TypeFieldEnum.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/TypeFieldEnum.scala
@@ -1,0 +1,9 @@
+package tools.jackson.module.scala.`enum`
+
+// a parameterized case carrying a field of its own actually called `type`
+enum TypeFieldEnum {
+  case Typed(`type`: String)
+  case Untyped
+}
+
+case class TypeFieldHolder(value: TypeFieldEnum)

--- a/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtSerializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtSerializerSpec.scala
@@ -15,7 +15,7 @@ class AdtSerializerSpec extends AnyWordSpec with Matchers {
     // the parameterized case is written as a JSON object tagged with a type marker
     // see https://github.com/FasterXML/jackson-module-scala/issues/831
     "serialize Color.Mix" in {
-      mapper.writeValueAsString(Color.Mix(0x4488FF)) shouldEqual (s"""{"type":"Mix","mix":4491519,"rgb":4491519}""")
+      mapper.writeValueAsString(Color.Mix(0x4488FF)) shouldEqual (s"""{"@type":"Mix","mix":4491519,"rgb":4491519}""")
     }
     "serialize ColorSet" in {
       val json = mapper.writeValueAsString(ColorSet(Set(Color.Red, Color.Green)))


### PR DESCRIPTION
Follow-up to #834, which tagged parameterized Scala 3 enum cases with a `type` property.

## Problem

A parameterized enum case can declare a field of its own called `type`, and when it did, the tag and the field collided into a **duplicate JSON key**:

```scala
enum TypeFieldEnum {
  case Typed(`type`: String)
  case Untyped
}
```

```json
{"value":{"type":"Typed","type":"custom"}}
```

## Fix

Tag with `@type` instead:

```json
{"value":{"@type":"Typed","type":"custom"}}
```

`@type` cannot clash with a plain Scala field name — declaring one requires backticks — and it is what Jackson itself uses by default for `JsonTypeInfo.Id.NAME`. It also lines up with the `@type` used by the marker-trait support in #835.

Enums carrying their own `@JsonTypeInfo` are unaffected; the property name there is whatever the annotation asks for, so `ShapeEnumAnnotated` still writes `{"type":"Circle","radius":1.5}`.

## Changed output

For enums **without** their own `@JsonTypeInfo`, this changes what #834 introduced:

| | before | after |
|---|---|---|
| `Result(ResultEnum.Ok("my-result"))` | `{"result":{"type":"Ok",…}}` | `{"result":{"@type":"Ok",…}}` |
| `Color.Mix(0x4488FF)` | `{"type":"Mix",…}` | `{"@type":"Mix",…}` |

Simple cases are untouched — they still serialize as their plain name (`"Pending"`, `"Red"`).

Worth landing before 3.3.0 ships, since #834 is unreleased and this is a wire-format change.

## Testing

`TypeFieldEnum` covers the case that motivated this. One honest note: the **serialization** assertion is what pins the behaviour down. The round trip passed even before the change — our reader takes the first `type` it sees as the tag and leaves the second for the field — so the deserialization test is coverage, not a regression test for the collision. I verified the serialization test fails on the old property name before committing.

Scala 3 **622 passed**, Scala 2.13 **578 passed**, mima clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263NLDeEasXcvWEYEvLa9u
