### PR TITLE
hold Scala 3 enum state per module instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,5 +178,14 @@ mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem]("tools.jackson.module.scala.ser.UnresolvedIteratorSerializer.withResolved"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("tools.jackson.module.scala.ser.IteratorSerializer.withResolved"),
   ProblemFilters.exclude[MissingClassProblem]("tools.jackson.module.scala.ser.EnumSerializerShared"),
-  ProblemFilters.exclude[MissingClassProblem]("tools.jackson.module.scala.ser.EnumSerializerShared$")
+  ProblemFilters.exclude[MissingClassProblem]("tools.jackson.module.scala.ser.EnumSerializerShared$"),
+  // Scala 3 enum support keeps its cache on the module instance rather than in a singleton. Holding
+  // that in a trait means a val, which Scala compiles to an accessor and a setter the implementing
+  // class has to provide, so anyone extending these traits has to recompile.
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.EnumModule.scala3EnumInfo"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.EnumModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_="),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.deser.EnumDeserializerModule.scala3EnumInfo"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.deser.EnumDeserializerModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_="),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.ser.EnumSerializerModule.scala3EnumInfo"),
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.ser.EnumSerializerModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_=")
 )

--- a/src/main/scala-3/tools/jackson/module/scala/BuiltinModules.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/BuiltinModules.scala
@@ -2,7 +2,8 @@ package tools.jackson.module.scala
 
 private[scala] object BuiltinModules {
   def addScalaVersionSpecificModules(builder: ScalaModule.Builder): ScalaModule.Builder = {
-    builder.addModule(EnumModule)
+    // a fresh instance, so a built module keeps its own enum state
+    builder.addModule(new EnumModule {})
     builder
   }
 }

--- a/src/main/scala-3/tools/jackson/module/scala/EnumModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/EnumModule.scala
@@ -5,20 +5,20 @@ import tools.jackson.module.scala.deser.EnumDeserializerModule
 import tools.jackson.module.scala.ser.EnumSerializerModule
 import tools.jackson.module.scala.util.Scala3EnumInfo
 
-trait EnumModule extends EnumSerializerModule with EnumDeserializerModule {
-  override def getModuleName: String = "EnumModule"
+/**
+ * The state Scala 3 enum support keeps, held per module instance rather than globally, so that a
+ * `ScalaModule` built through [[ScalaModule.Builder]] has a cache and cache settings of its own.
+ * Mixing both halves of the module together yields one shared instance.
+ *
+ * @since 3.3.0
+ */
+trait Scala3EnumSupportState {
 
-  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
-    EnumSerializerModule.getInitializers(config) ++
-      EnumDeserializerModule.getInitializers(config)
-  }
-}
-
-object EnumModule extends EnumModule {
+  private[scala] val scala3EnumInfo: Scala3EnumInfo = new Scala3EnumInfo
 
   /**
-   * Replaces the [[LookupCacheFactory]] used for the cache of Scala 3 enum case tables. The default
-   * factory uses [[tools.jackson.databind.util.SimpleLookupCache]].
+   * Replaces the [[LookupCacheFactory]] used by this module instance for its cache of Scala 3 enum
+   * case tables. The default factory uses [[tools.jackson.databind.util.SimpleLookupCache]].
    * <p>
    * Note that this clears the existing cache entries. The cache is only a memo of what can be
    * derived reflectively from an enum class, so clearing it affects performance but not behaviour.
@@ -29,10 +29,10 @@ object EnumModule extends EnumModule {
    * @since 3.3.0
    */
   def setLookupCacheFactory(lookupCacheFactory: LookupCacheFactory): Unit =
-    Scala3EnumInfo.setLookupCacheFactory(lookupCacheFactory)
+    scala3EnumInfo.setLookupCacheFactory(lookupCacheFactory)
 
   /**
-   * Resize the cache of Scala 3 enum case tables. The default size is 1000.
+   * Resize this module instance's cache of Scala 3 enum case tables. The default size is 1000.
    * <p>
    * The cache is bounded so that enum classes loaded by a short lived classloader are not retained
    * indefinitely. Entries are keyed by class, and an evicted entry is rebuilt on the next lookup.
@@ -45,12 +45,22 @@ object EnumModule extends EnumModule {
    * @see [[setLookupCacheFactory]]
    * @since 3.3.0
    */
-  def setEnumInfoCacheSize(size: Int): Unit = Scala3EnumInfo.setCacheSize(size)
+  def setEnumInfoCacheSize(size: Int): Unit = scala3EnumInfo.setCacheSize(size)
 
   /**
-   * Empties the cache of Scala 3 enum case tables.
+   * Empties this module instance's cache of Scala 3 enum case tables.
    *
    * @since 3.3.0
    */
-  def clearEnumInfoCache(): Unit = Scala3EnumInfo.clearCache()
+  def clearEnumInfoCache(): Unit = scala3EnumInfo.clearCache()
 }
+
+trait EnumModule extends EnumSerializerModule with EnumDeserializerModule {
+  override def getModuleName: String = "EnumModule"
+
+  // built from this instance's state, not from the two singleton halves
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] =
+    serializerInitializers(config) ++ deserializerInitializers(config)
+}
+
+object EnumModule extends EnumModule

--- a/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
@@ -5,7 +5,7 @@ import tools.jackson.databind.deser.{Deserializers, KeyDeserializers}
 import tools.jackson.databind.deser.std.StdDeserializer
 import tools.jackson.databind._
 import tools.jackson.databind.JacksonModule.SetupContext
-import tools.jackson.module.scala.{JacksonModule, ScalaModule}
+import tools.jackson.module.scala.{JacksonModule, ScalaModule, Scala3EnumSupportState}
 import tools.jackson.module.scala.JacksonModule.InitializerBuilder
 import tools.jackson.module.scala.util.Scala3EnumInfo
 
@@ -69,10 +69,6 @@ private[scala] object EnumDeserializerShared {
     }
   }
 
-  // Scala 3 enums that mix parameterized and simple cases have neither valueOf nor a usable
-  // fromOrdinal, so they are handled from the reflective case table instead.
-  def taggedSumInfo(clz: Class[_]): Option[Scala3EnumInfo.Info] =
-    Scala3EnumInfo.infoFor(clz).filter(_.isTaggedSum)
 }
 
 private case class EnumDeserializer[T <: Enum](clazz: Class[T]) extends StdDeserializer[T](clazz) {
@@ -146,7 +142,7 @@ private case class EnumKeyDeserializer[T <: Enum](clazz: Class[T]) extends KeyDe
   }
 }
 
-private class EnumDeserializerResolver(config: ScalaModule.Config) extends Deserializers.Base {
+private class EnumDeserializerResolver(config: ScalaModule.Config, enumInfo: Scala3EnumInfo) extends Deserializers.Base {
   override def findBeanDeserializer(javaType: JavaType, config: DeserializationConfig, beanDesc: BeanDescription.Supplier): ValueDeserializer[Enum] =
     deserializerFor(javaType.getRawClass).orNull
 
@@ -155,7 +151,7 @@ private class EnumDeserializerResolver(config: ScalaModule.Config) extends Deser
 
   private def deserializerFor(rawClass: Class[_]): Option[ValueDeserializer[Enum]] = {
     if (!EnumDeserializerShared.EnumClass.isAssignableFrom(rawClass)) None
-    else EnumDeserializerShared.taggedSumInfo(rawClass) match {
+    else enumInfo.taggedSumInfo(rawClass) match {
       // the generated case classes are left to the standard bean deserializer
       case Some(info) => if (info.rootClass == rawClass) Some(Scala3EnumSumDeserializer(info)) else None
       case None =>
@@ -172,15 +168,18 @@ private class EnumKeyDeserializerResolver(config: ScalaModule.Config) extends Ke
     else None.orNull
 }
 
-trait EnumDeserializerModule extends JacksonModule {
+trait EnumDeserializerModule extends JacksonModule with Scala3EnumSupportState {
   override def getModuleName: String = "EnumDeserializerModule"
 
-  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
+  protected def deserializerInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
     val builder = new InitializerBuilder()
-    builder += new EnumDeserializerResolver(config)
+    builder += new EnumDeserializerResolver(config, scala3EnumInfo)
     builder += new EnumKeyDeserializerResolver(config)
     builder.build()
   }
+
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] =
+    deserializerInitializers(config)
 }
 
 object EnumDeserializerModule extends EnumDeserializerModule

--- a/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
@@ -82,6 +82,9 @@ private class EnumSerializerModifier(config: ScalaModule.Config, enumInfo: Scala
                                 serializer: ValueSerializer[_]): ValueSerializer[_] = {
     val rawClass = beanDesc.getBeanClass
     enumInfo.taggedSumInfo(rawClass).flatMap(_.parameterizedCaseFor(rawClass)) match {
+      // registering the module twice would otherwise wrap a wrapper, and the inner one would write
+      // a whole object where the outer expected only properties
+      case Some(_) if serializer.isInstanceOf[Scala3EnumCaseSerializer] => serializer
       case Some(enumCase) => new Scala3EnumCaseSerializer(enumCase.name, serializer.asInstanceOf[ValueSerializer[AnyRef]])
       case None => serializer
     }

--- a/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/ser/EnumSerializerModule.scala
@@ -6,7 +6,7 @@ import tools.jackson.databind.ser.{Serializers, ValueSerializerModifier}
 import tools.jackson.databind._
 import tools.jackson.databind.JacksonModule.SetupContext
 import tools.jackson.databind.util.NameTransformer
-import tools.jackson.module.scala.{JacksonModule, ScalaModule}
+import tools.jackson.module.scala.{JacksonModule, ScalaModule, Scala3EnumSupportState}
 import tools.jackson.module.scala.JacksonModule.InitializerBuilder
 import tools.jackson.module.scala.deser.EnumDeserializerShared
 import tools.jackson.module.scala.util.Scala3EnumInfo
@@ -64,12 +64,12 @@ private class Scala3EnumCaseSerializer(typeName: String, delegate: ValueSerializ
   }
 }
 
-private class EnumSerializerResolver(config: ScalaModule.Config) extends Serializers.Base {
+private class EnumSerializerResolver(config: ScalaModule.Config, enumInfo: Scala3EnumInfo) extends Serializers.Base {
   override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription.Supplier,
                               formatOverrides: JsonFormat.Value): ValueSerializer[Enum] = {
     val rawClass = javaType.getRawClass
     if (!EnumDeserializerShared.EnumClass.isAssignableFrom(rawClass)) None.orNull
-    else EnumDeserializerShared.taggedSumInfo(rawClass) match {
+    else enumInfo.taggedSumInfo(rawClass) match {
       // the generated case classes are serialized as beans, tagged by EnumSerializerModifier
       case Some(info) => if (info.parameterizedCaseFor(rawClass).isDefined) None.orNull else Scala3EnumSumSerializer(info)
       case None => if (EnumDeserializerShared.canFindByOrdinal(rawClass)) EnumSerializer else None.orNull
@@ -77,11 +77,11 @@ private class EnumSerializerResolver(config: ScalaModule.Config) extends Seriali
   }
 }
 
-private class EnumSerializerModifier(config: ScalaModule.Config) extends ValueSerializerModifier {
+private class EnumSerializerModifier(config: ScalaModule.Config, enumInfo: Scala3EnumInfo) extends ValueSerializerModifier {
   override def modifySerializer(config: SerializationConfig, beanDesc: BeanDescription.Supplier,
                                 serializer: ValueSerializer[_]): ValueSerializer[_] = {
     val rawClass = beanDesc.getBeanClass
-    EnumDeserializerShared.taggedSumInfo(rawClass).flatMap(_.parameterizedCaseFor(rawClass)) match {
+    enumInfo.taggedSumInfo(rawClass).flatMap(_.parameterizedCaseFor(rawClass)) match {
       case Some(enumCase) => new Scala3EnumCaseSerializer(enumCase.name, serializer.asInstanceOf[ValueSerializer[AnyRef]])
       case None => serializer
     }
@@ -96,16 +96,19 @@ private class EnumKeySerializerResolver(config: ScalaModule.Config) extends Seri
     else None.orNull
 }
 
-trait EnumSerializerModule extends JacksonModule {
+trait EnumSerializerModule extends JacksonModule with Scala3EnumSupportState {
   override def getModuleName: String = "EnumSerializerModule"
 
-  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
+  protected def serializerInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
     val builder = new InitializerBuilder()
-    builder += new EnumSerializerResolver(config)
-    builder += new EnumSerializerModifier(config)
+    builder += new EnumSerializerResolver(config, scala3EnumInfo)
+    builder += new EnumSerializerModifier(config, scala3EnumInfo)
     builder.addKeySerializers(new EnumKeySerializerResolver(config))
     builder.build()
   }
+
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] =
+    serializerInitializers(config)
 }
 
 object EnumSerializerModule extends EnumSerializerModule

--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -17,6 +17,10 @@ import scala.util.Try
  * the compiler emits one public static field per case on the enum companion, holding either the
  * singleton instance (simple case) or the companion object of the generated case class
  * (parameterized case).
+ *
+ * Deriving a table depends on nothing but the enum class, so it lives here. Remembering one is
+ * state, and lives on the [[Scala3EnumInfo]] instance rather than here, so that a module built with
+ * [[tools.jackson.module.scala.ScalaModule.Builder]] keeps its own.
  */
 private[scala] object Scala3EnumInfo {
 
@@ -52,51 +56,10 @@ private[scala] object Scala3EnumInfo {
     def parameterizedCaseFor(clazz: Class[_]): Option[EnumCase] = casesByClass.get(clazz)
   }
 
-  private var _lookupCacheFactory: LookupCacheFactory = DefaultLookupCacheFactory
-  private var _cacheSize: Int = 1000
+  private[scala] def isEnumClass(clazz: Class[_]): Boolean =
+    clazz != null && EnumClass.isAssignableFrom(clazz)
 
-  // Bounded so that classes loaded by a child classloader (hot redeploy, OSGi, script engines) are
-  // not retained indefinitely by this object. Keyed by Class rather than by class name because the
-  // cached Info holds Class instances - two same-named enums from different classloaders must not
-  // share an entry. The cache is a pure memo - an evicted entry is rebuilt on the next lookup.
-  @volatile private var _cache: LookupCache[Class[_], Option[Info]] =
-    _lookupCacheFactory.createLookupCache(16, _cacheSize)
-
-  /**
-   * Returns the case table of the Scala 3 enum that `clazz` belongs to - `clazz` may be the enum
-   * itself, one of its parameterized case classes, or the anonymous class used for its simple cases.
-   */
-  def infoFor(clazz: Class[_]): Option[Info] = {
-    if (clazz == null || !EnumClass.isAssignableFrom(clazz)) None
-    else {
-      val cache = _cache
-      Option(cache.get(clazz)) match {
-        case Some(info) => info
-        case _ =>
-          val info = findInfo(clazz)
-          Option(cache.putIfAbsent(clazz, info)).getOrElse(info)
-      }
-    }
-  }
-
-  def setLookupCacheFactory(lookupCacheFactory: LookupCacheFactory): Unit = {
-    _lookupCacheFactory = lookupCacheFactory
-    recreateCache()
-  }
-
-  def setCacheSize(size: Int): Unit = {
-    _cacheSize = size
-    recreateCache()
-  }
-
-  def clearCache(): Unit = _cache.clear()
-
-  private def recreateCache(): Unit = {
-    _cache.clear()
-    _cache = _lookupCacheFactory.createLookupCache(16, _cacheSize)
-  }
-
-  private def findInfo(clazz: Class[_]): Option[Info] = {
+  private[scala] def findInfo(clazz: Class[_]): Option[Info] = {
     var current: Class[_] = clazz
     var result: Option[Info] = None
     while (result.isEmpty && current != null && EnumClass.isAssignableFrom(current)) {
@@ -140,4 +103,63 @@ private[scala] object Scala3EnumInfo {
 
   private def loaderFor(clazz: Class[_]): ClassLoader =
     Option(clazz.getClassLoader).getOrElse(ClassLoader.getSystemClassLoader)
+}
+
+/**
+ * Remembers the case table of each Scala 3 enum met.
+ *
+ * One of these belongs to each module instance, so a `ScalaModule` built through its builder keeps
+ * its own cache and its own cache settings, while the `DefaultScalaModule` object shares the one
+ * that comes with the [[tools.jackson.module.scala.EnumModule]] object.
+ */
+private[scala] class Scala3EnumInfo {
+
+  import Scala3EnumInfo._
+
+  private var _lookupCacheFactory: LookupCacheFactory = DefaultLookupCacheFactory
+  private var _cacheSize: Int = 1000
+
+  // Bounded so that classes loaded by a child classloader (hot redeploy, OSGi, script engines) are
+  // not retained indefinitely. Keyed by Class rather than by class name because the cached Info
+  // holds Class instances - two same-named enums from different classloaders must not share an
+  // entry. The cache is a pure memo - an evicted entry is rebuilt on the next lookup.
+  @volatile private var _cache: LookupCache[Class[_], Option[Info]] =
+    _lookupCacheFactory.createLookupCache(16, _cacheSize)
+
+  /**
+   * Returns the case table of the Scala 3 enum that `clazz` belongs to - `clazz` may be the enum
+   * itself, one of its parameterized case classes, or the anonymous class used for its simple cases.
+   */
+  def infoFor(clazz: Class[_]): Option[Info] = {
+    if (!isEnumClass(clazz)) None
+    else {
+      val cache = _cache
+      Option(cache.get(clazz)) match {
+        case Some(info) => info
+        case _ =>
+          val info = findInfo(clazz)
+          Option(cache.putIfAbsent(clazz, info)).getOrElse(info)
+      }
+    }
+  }
+
+  /** Enums that mix parameterized and simple cases, which are tagged rather than named. */
+  def taggedSumInfo(clazz: Class[_]): Option[Info] = infoFor(clazz).filter(_.isTaggedSum)
+
+  def setLookupCacheFactory(lookupCacheFactory: LookupCacheFactory): Unit = {
+    _lookupCacheFactory = lookupCacheFactory
+    recreateCache()
+  }
+
+  def setCacheSize(size: Int): Unit = {
+    _cacheSize = size
+    recreateCache()
+  }
+
+  def clearCache(): Unit = _cache.clear()
+
+  private def recreateCache(): Unit = {
+    _cache.clear()
+    _cache = _lookupCacheFactory.createLookupCache(16, _cacheSize)
+  }
 }

--- a/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
@@ -42,13 +42,21 @@ object ScalaModule {
     }
 
     def removeModule(module: JacksonModule): Builder = {
-      modules.-=(module)
+      val remaining = modules.filterNot(sameModule(_, module)).toList
+      modules.clear()
+      modules.++=(remaining)
       this
     }
 
     def hasModule(module: JacksonModule): Boolean = {
-      modules.contains(module)
+      modules.exists(sameModule(_, module))
     }
+
+    // Some builtin modules are registered as an instance of their own, so that a built module keeps
+    // state independent of the module object. Matching on the module name as well as on the
+    // instance keeps `removeModule(EnumModule)` working for those.
+    private def sameModule(existing: JacksonModule, module: JacksonModule): Boolean =
+      existing == module || existing.getModuleName == module.getModuleName
 
     def addAllBuiltinModules(): Builder = {
       addModule(IteratorModule)

--- a/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
@@ -37,7 +37,8 @@ object ScalaModule {
     override def shouldDeserializeNullCollectionsAsEmpty(): Boolean = deserializeNullCollectionsAsEmpty
 
     def addModule(module: JacksonModule): Builder = {
-      modules.+=(module)
+      // a module registered twice would contribute its serializers and deserializers twice over
+      if (!hasModule(module)) modules.+=(module)
       this
     }
 

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumModuleStateSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumModuleStateSpec.scala
@@ -41,6 +41,19 @@ class EnumModuleStateSpec extends AnyWordSpec with Matchers {
       val mapper = JsonMapper.builder().addModule(builder.build()).build()
       mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) should not include "@type"
     }
+    "not tag twice when the module is registered again alongside DefaultScalaModule" in {
+      val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(new EnumModule {}).build()
+      val instance = Result(ResultEnum.Ok("my-result"))
+      mapper.writeValueAsString(instance) shouldEqual """{"result":{"@type":"Ok","value":"my-result"}}"""
+      mapper.readValue(mapper.writeValueAsString(instance), classOf[Result]) shouldEqual instance
+    }
+    "register a builtin module only once per builder" in {
+      val built = ScalaModule.builder().addAllBuiltinModules().addAllBuiltinModules().build()
+      val mapper = JsonMapper.builder().addModule(built).build()
+      val instance = Result(ResultEnum.Ok("my-result"))
+      mapper.writeValueAsString(instance) shouldEqual """{"result":{"@type":"Ok","value":"my-result"}}"""
+      mapper.readValue(mapper.writeValueAsString(instance), classOf[Result]) shouldEqual instance
+    }
     "rebuild a case table after the instance cache is cleared" in {
       val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
       val instance = Result(ResultEnum.Error(123))

--- a/src/test/scala-3/tools/jackson/module/scala/enum/EnumModuleStateSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/EnumModuleStateSpec.scala
@@ -1,0 +1,62 @@
+package tools.jackson.module.scala.`enum`
+
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.{DefaultScalaModule, EnumModule, ScalaModule}
+import tools.jackson.module.scala.deser.EnumDeserializerModule
+import tools.jackson.module.scala.ser.EnumSerializerModule
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * The cache of enum case tables belongs to a module instance, so a mapper built from its own
+ * ScalaModule does not share it with every other mapper in the process.
+ */
+class EnumModuleStateSpec extends AnyWordSpec with Matchers {
+
+  "EnumModule" should {
+    "give each module instance state of its own" in {
+      val first = new EnumModule {}
+      val second = new EnumModule {}
+      first.scala3EnumInfo should not be theSameInstanceAs(second.scala3EnumInfo)
+      EnumModule.scala3EnumInfo should not be theSameInstanceAs(first.scala3EnumInfo)
+    }
+    "share one instance between the two halves of a module" in {
+      val module = new EnumModule {}
+      (module: EnumSerializerModule).scala3EnumInfo should be theSameInstanceAs
+        (module: EnumDeserializerModule).scala3EnumInfo
+    }
+    "tie the state of a built ScalaModule to that build" in {
+      val builder = ScalaModule.builder().addAllBuiltinModules()
+      val mapper = JsonMapper.builder().addModule(builder.build()).build()
+      val instance = Result(ResultEnum.Ok("my-result"))
+      mapper.writeValueAsString(instance) shouldEqual """{"result":{"@type":"Ok","value":"my-result"}}"""
+      mapper.readValue(mapper.writeValueAsString(instance), classOf[Result]) shouldEqual instance
+    }
+    "still recognise the module object when removing it from a builder" in {
+      val builder = ScalaModule.builder().addAllBuiltinModules()
+      builder.hasModule(EnumModule) shouldEqual true
+      builder.removeModule(EnumModule)
+      builder.hasModule(EnumModule) shouldEqual false
+      // without the enum module the parameterized case is no longer tagged
+      val mapper = JsonMapper.builder().addModule(builder.build()).build()
+      mapper.writeValueAsString(Result(ResultEnum.Ok("my-result"))) should not include "@type"
+    }
+    "rebuild a case table after the instance cache is cleared" in {
+      val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
+      val instance = Result(ResultEnum.Error(123))
+      mapper.writeValueAsString(instance) shouldEqual """{"result":{"@type":"Error","code":123}}"""
+      EnumModule.clearEnumInfoCache()
+      val fresh = JsonMapper.builder().addModule(DefaultScalaModule).build()
+      fresh.readValue(fresh.writeValueAsString(instance), classOf[Result]) shouldEqual instance
+    }
+    "leave one module instance's cache untouched when another is cleared" in {
+      val mine = new EnumModule {}
+      val mapper = JsonMapper.builder().addModule(ScalaModule.builder().addAllBuiltinModules().build()).build()
+      val instance = Result(ResultEnum.Ok("my-result"))
+      mapper.writeValueAsString(instance) shouldEqual """{"result":{"@type":"Ok","value":"my-result"}}"""
+      mine.clearEnumInfoCache()
+      EnumModule.clearEnumInfoCache()
+      mapper.readValue(mapper.writeValueAsString(instance), classOf[Result]) shouldEqual instance
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #834/#836, from an audit of where module state lives.

## Problem

The cache of Scala 3 enum case tables, and its settings, lived in the `Scala3EnumInfo` **object**:

```scala
private[scala] object Scala3EnumInfo {
  private var _lookupCacheFactory = ...
  private var _cacheSize: Int = 1000
  @volatile private var _cache: LookupCache[Class[_], Option[Info]] = ...
}
```

So every mapper in a process shared one cache and one set of cache settings, and `new EnumModule {}` got no state of its own — `EnumModule.setEnumInfoCacheSize` was process-wide however the module was constructed.

## Change

`Scala3EnumInfo` (object) now keeps only what *derives* a table from an enum class, which depends on nothing but that class. *Remembering* a table is state, and moved to a `Scala3EnumInfo` instance.

`Scala3EnumSupportState` carries that instance plus the cache settings and is mixed into both halves of the module, so mixing them yields **one** shared instance rather than two. That also required `EnumModule.getInitializers` to build from its own state — it previously delegated to `EnumSerializerModule`/`EnumDeserializerModule`, the singleton halves, and so would have used theirs.

The public setters on the `EnumModule` object are unchanged for callers; they are now inherited and act on that object's instance.

`ScalaModule.Builder` registers an `EnumModule` of its own, so a module built through the builder keeps its own cache, while `DefaultScalaModule` continues to share the one on the `EnumModule` object.

## One shared-code change worth reviewing

Registering a fresh instance broke `removeModule`/`hasModule`: they matched by **equality**, so `builder.removeModule(EnumModule)` — the object — would not have matched the builder's instance and removal would have **silently done nothing**. They now also match on `getModuleName`.

That is a small change to public `Builder` semantics for every module, so flagging it explicitly. The alternative was to expose the builder's instance and require callers to pass that, which keeps equality matching but makes `removeModule(EnumModule)` a silent no-op — worse, in my view. Happy to switch if you disagree.

## Duplicate registration

Registering the enum module twice — a custom `EnumModule` alongside `DefaultScalaModule`, which already contributes its initializers — wrapped the tagged serializer in another tagged serializer. The inner one then wrote a whole object where the outer expected only properties:

```
StreamWriteException: Cannot start an object, expecting a property name (context: Object)
```

Jackson cannot dedupe this, because from its side those are two different modules; the duplication is inside how the module is composed. Fixed at both layers: the serializer modifier leaves a serializer it has already wrapped alone, and `ScalaModule.Builder.addModule` skips a module it already holds.

## mima

Holding the cache on the module instance means a trait `val`, which Scala compiles to an accessor and a setter the implementing class provides. mima reports that against 3.0.0 for the three traits that already existed — `EnumModule`, `EnumSerializerModule`, `EnumDeserializerModule` — since a class compiled against 3.0.0 would no longer implement them.

Six `InheritedNewAbstractMethodProblem` filters added. The practical consequence: **anyone extending those three traits has to recompile**. Ordinary users of `DefaultScalaModule` are unaffected. Flagging it since it is a real, if narrow, break — say if you would rather have the state some other way.

## Testing

New `EnumModuleStateSpec`: distinct instances per module, both halves sharing one, a builder-built `ScalaModule` tagging and round-tripping through its own state, `removeModule(EnumModule)` actually disabling the module, a cleared cache rebuilding, and both duplicate-registration paths.

Scala 3 **630 passed**, Scala 2.13 **578 passed**. mima clean on 2.12, 2.13 and 3.3.8 (CI runs it across the whole matrix, and only the Scala 3 run was failing).

## Note, not fixed here

`ScalaAnnotationIntrospectorModule` has the opposite shape: its state *is* in the trait body, so instances would get their own, but `addAllBuiltinModules` registers the object — so a builder-built module still shares the singleton's descriptor and scala-type caches, including the `overrideMap` that `registerReferencedValueType` mutates. Left alone because changing it shifts which cache existing builder users hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263NLDeEasXcvWEYEvLa9u

