### PR TITLE
give each builder its own annotation introspection state

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
@@ -19,6 +19,16 @@ object ScalaModule {
 
   class Builder extends Config {
     private val modules = scala.collection.mutable.Buffer[JacksonModule]()
+
+    /**
+     * This builder's own annotation introspection, with caches, cache settings and referenced value
+     * type registrations independent of every other builder and of the
+     * [[tools.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule]] object.
+     *
+     * @since 3.3.0
+     */
+    val scalaAnnotationIntrospectorModule: ScalaAnnotationIntrospectorModule =
+      ScalaAnnotationIntrospectorModule.newStandaloneInstance()
     private var supportScala3Classes = true
     private var deserializeNullCollectionsAsEmpty = true
 
@@ -68,7 +78,7 @@ object ScalaModule {
       addModule(MapModule)
       addModule(SetModule)
       addModule(ScalaNumberDeserializersModule)
-      addModule(ScalaAnnotationIntrospectorModule)
+      addModule(scalaAnnotationIntrospectorModule)
       addModule(ScalaObjectDeserializerModule)
       addModule(UntypedObjectDeserializerModule)
       addModule(EitherModule)

--- a/src/main/scala/tools/jackson/module/scala/introspect/JavaAnnotationIntrospector.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/JavaAnnotationIntrospector.scala
@@ -11,13 +11,18 @@ import scala.reflect.NameTransformer
 
 object JavaAnnotationIntrospector extends JavaAnnotationIntrospectorInstance(ScalaModule.defaultBuilder)
 
-class JavaAnnotationIntrospectorInstance(cfg: ScalaModule.Config) extends NopAnnotationIntrospector {
+class JavaAnnotationIntrospectorInstance(cfg: ScalaModule.Config,
+                                         introspectorModule: ScalaAnnotationIntrospectorModule)
+  extends NopAnnotationIntrospector {
+
+  // kept so that the previous constructor still resolves; it uses the module object's state
+  def this(cfg: ScalaModule.Config) = this(cfg, ScalaAnnotationIntrospectorModule)
 
   override def findNameForDeserialization(mapperConfig: MapperConfig[_], a: Annotated): PropertyName = None.orNull
 
   override def findImplicitPropertyName(mapperConfig: MapperConfig[_], param: AnnotatedMember): String = {
     val result = param match {
-      case param: AnnotatedParameter if ScalaAnnotationIntrospectorModule.isMaybeScalaBeanType(param.getDeclaringClass) => {
+      case param: AnnotatedParameter if introspectorModule.isMaybeScalaBeanType(param.getDeclaringClass) => {
         val index = param.getIndex
         val owner = param.getOwner
         owner.getAnnotated match {

--- a/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -271,7 +271,8 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
   override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
     val builder = new InitializerBuilder()
     val sai = new ScalaAnnotationIntrospectorInstance(this, config)
-    builder += { _.appendAnnotationIntrospector(new JavaAnnotationIntrospectorInstance(config)) }
+    // this instance's state, not the module object's
+    builder += { _.appendAnnotationIntrospector(new JavaAnnotationIntrospectorInstance(config, this)) }
     builder += { _.appendAnnotationIntrospector(sai) }
     builder += { _.addValueInstantiators(sai) }
     builder.build()

--- a/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
+++ b/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
@@ -1,0 +1,51 @@
+package tools.jackson.module.scala.introspect
+
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.ScalaModule
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+case class IntrospectorStateHolder(valueLong: Option[Long])
+
+/**
+ * The introspector's caches and its registered referenced value types belong to a module instance,
+ * so a mapper built from its own ScalaModule does not share them with every other mapper.
+ */
+class ScalaAnnotationIntrospectorStateSpec extends AnyWordSpec with Matchers {
+
+  "ScalaAnnotationIntrospectorModule" should {
+    "give each builder its own introspector instance" in {
+      val first = ScalaModule.builder()
+      val second = ScalaModule.builder()
+      first.scalaAnnotationIntrospectorModule should not be
+        theSameInstanceAs(second.scalaAnnotationIntrospectorModule)
+      first.scalaAnnotationIntrospectorModule should not be
+        theSameInstanceAs(ScalaAnnotationIntrospectorModule)
+    }
+    "keep a referenced value type registration to the builder it was made on" in {
+      val builder = ScalaModule.builder().addAllBuiltinModules()
+      try {
+        builder.scalaAnnotationIntrospectorModule
+          .registerReferencedValueType(classOf[IntrospectorStateHolder], "valueLong", classOf[Long])
+        builder.scalaAnnotationIntrospectorModule
+          .getRegisteredReferencedValueType(classOf[IntrospectorStateHolder], "valueLong") shouldEqual Some(classOf[Long])
+        // the module object knows nothing of it
+        ScalaAnnotationIntrospectorModule
+          .getRegisteredReferencedValueType(classOf[IntrospectorStateHolder], "valueLong") shouldBe empty
+      } finally {
+        builder.scalaAnnotationIntrospectorModule.clearRegisteredReferencedTypes()
+      }
+    }
+    "still recognise the module object when removing it from a builder" in {
+      val builder = ScalaModule.builder().addAllBuiltinModules()
+      builder.hasModule(ScalaAnnotationIntrospectorModule) shouldEqual true
+      builder.removeModule(ScalaAnnotationIntrospectorModule)
+      builder.hasModule(ScalaAnnotationIntrospectorModule) shouldEqual false
+    }
+    "read a case class through a module built by the builder" in {
+      val mapper = JsonMapper.builder().addModule(ScalaModule.builder().addAllBuiltinModules().build()).build()
+      val value = IntrospectorStateHolder(Some(3L))
+      mapper.readValue(mapper.writeValueAsString(value), classOf[IntrospectorStateHolder]) shouldEqual value
+    }
+  }
+}


### PR DESCRIPTION
Completes the state audit that produced #837. This is the case I noted there as "not fixed here".

## Problem

`ScalaAnnotationIntrospectorModule` already held its state in the **trait** — `_descriptorCache`, `_scalaTypeCache`, `_lookupCacheFactory`, the two cache sizes and `overrideMap` — so `newStandaloneInstance()` genuinely gave a caller state of its own. The wiring did not use that:

```scala
addModule(ScalaAnnotationIntrospectorModule)   // the object
```

So a module built through `ScalaModule.builder()` still shared the object's descriptor cache, scala-type cache and `overrideMap` with every other mapper in the process.

There was also a second, less visible leak: `JavaAnnotationIntrospectorInstance` reached for the module **object** rather than the module that registered it, so its `isMaybeScalaBeanType` check consulted the object's scala-type cache whichever instance was in use.

## Change

`ScalaModule.Builder` holds an instance of its own, exposed so the per-build state can actually be reached:

```scala
val builder = ScalaModule.builder().addAllBuiltinModules()
builder.scalaAnnotationIntrospectorModule
  .registerReferencedValueType(classOf[Holder], "valueLong", classOf[Long])   // this build only
```

`JavaAnnotationIntrospectorInstance` now takes the module it belongs to. The previous single-argument constructor is kept and still uses the object, so `JavaAnnotationIntrospector` and any external caller are unaffected.

`DefaultScalaModule` continues to share the object's state, as with the enum module in #837.

`removeModule(ScalaAnnotationIntrospectorModule)` still works, since #837 made `removeModule`/`hasModule` match on module name as well as identity.

## Behaviour change worth noting

A `registerReferencedValueType` call made on the **object** is no longer seen by a module built through the builder. That is the point of the change — the two were only connected before because the builder used the object — but it is a real difference for anyone combining the two. Callers using `DefaultScalaModule`, which is how the existing tests and docs use it, are unaffected.

## Testing

New `ScalaAnnotationIntrospectorStateSpec`: distinct instances per builder, a registration staying on the builder it was made on and not reaching the object, `removeModule` still matching the object, and a builder-built module reading a case class end to end.

Scala 2.12 **575 passed**, Scala 2.13 **578 passed**, Scala 3 **634 passed**. mima clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263NLDeEasXcvWEYEvLa9u
