### PR TITLE
add a Scala 3 derives alternative to the marker trait

### DIFF
--- a/src/main/scala-2.+/tools/jackson/module/scala/util/SubtypeLookup.scala
+++ b/src/main/scala-2.+/tools/jackson/module/scala/util/SubtypeLookup.scala
@@ -33,6 +33,9 @@ private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
   /** Scala 2 has no `scala.reflect.Enum` - `Enumeration` is handled by a different module. */
   def isScalaEnum(clazz: Class[_]): Boolean = false
 
+  /** Deriving is a Scala 3 way of capturing a hierarchy; Scala 2 reads it from the class file. */
+  def isDerived(clazz: Class[_]): Boolean = false
+
   def checkAvailable(clazz: Class[_]): Unit = {
     if (!scalaReflectAvailable) {
       throw new IllegalStateException(

--- a/src/main/scala-3/tools/jackson/module/scala/SealedSubtypes.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/SealedSubtypes.scala
@@ -1,0 +1,73 @@
+package tools.jackson.module.scala
+
+import scala.quoted.*
+
+/**
+ * Captures the implementations of a `sealed` hierarchy at compile time, so that Scala 3 can enumerate
+ * one the way Scala 2 does through scala-reflect.
+ *
+ * Derive it on the base and the hierarchy is marked, exactly as extending
+ * [[SealedPolymorphismSupport]] marks one - the two produce identical JSON:
+ *
+ * {{{
+ * sealed trait Animal derives SealedSubtypes
+ * case class Dog(name: String) extends Animal
+ * case object Unknown extends Animal
+ *
+ * // {"@type":"Dog","name":"rex"}
+ * }}}
+ *
+ * Deriving buys what Scala 3 cannot work out for itself. The compiler rejects a base that is not
+ * `sealed`, and an implementation is found from the table rather than from where it was declared, so
+ * one declared somewhere the marker alone could not reach is still read back, and a name claimed by
+ * two implementations is reported for the whole hierarchy at once.
+ *
+ * @since 3.3.0
+ */
+trait SealedSubtypes[T] {
+  /** Every implementation of the hierarchy, with the instance of each one that is an object. */
+  def subtypes: Seq[(Class[?], Option[AnyRef])]
+}
+
+object SealedSubtypes {
+
+  inline def derived[T]: SealedSubtypes[T] = ${ derivedImpl[T] }
+
+  private def derivedImpl[T: Type](using Quotes): Expr[SealedSubtypes[T]] = {
+    import quotes.reflect.*
+
+    val root = TypeRepr.of[T].dealias.typeSymbol
+    if (!root.flags.is(Flags.Sealed)) {
+      report.errorAndAbort(
+        s"${root.fullName} is not sealed. SealedSubtypes can only be derived for a sealed hierarchy, " +
+          "since only then are all of its implementations known.")
+    }
+
+    // an abstract class or trait part way down holds no value of its own, but what is below it
+    // still belongs to the hierarchy; a concrete one is both
+    def implementations(symbol: Symbol): List[Symbol] = symbol.children.flatMap { child =>
+      val below = if (child.flags.is(Flags.Sealed)) implementations(child) else Nil
+      val itself = if (child.flags.is(Flags.Abstract) || child.flags.is(Flags.Trait)) Nil else List(child)
+      itself ++ below
+    }
+
+    val found = implementations(root)
+    if (found.isEmpty) report.errorAndAbort(s"${root.fullName} has no implementations to derive from")
+
+    val entries = found.map { child =>
+      val clazz = Literal(ClassOfConstant(child.typeRef)).asExprOf[Class[?]]
+      if (child.flags.is(Flags.Module)) {
+        val instance = Ref(child.companionModule).asExprOf[Any]
+        '{ ($clazz, Some($instance.asInstanceOf[AnyRef])) }
+      } else {
+        '{ ($clazz, None) }
+      }
+    }
+
+    '{
+      new SealedSubtypes[T] {
+        override def subtypes: Seq[(Class[?], Option[AnyRef])] = Seq(${ Varargs(entries) }*)
+      }
+    }
+  }
+}

--- a/src/main/scala-3/tools/jackson/module/scala/util/SubtypeLookup.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/SubtypeLookup.scala
@@ -1,5 +1,7 @@
 package tools.jackson.module.scala.util
 
+import tools.jackson.databind.util.LookupCache
+import tools.jackson.module.scala.{DefaultLookupCacheFactory, SealedSubtypes}
 import tools.jackson.module.scala.util.SealedPolymorphism.Subtype
 
 import java.lang.reflect.Modifier
@@ -14,6 +16,10 @@ import scala.util.Try
  * and reading one only needs to turn a name back into a class - so a name is resolved by rebuilding
  * the class names an implementation could have been compiled to, from where the root is declared,
  * and keeping only candidates that really are subtypes of the base.
+ *
+ * Unless the hierarchy derives [[tools.jackson.module.scala.SealedSubtypes]], which captures its
+ * implementations while the compiler still knows them. That table is exact, so it is preferred
+ * wherever it exists and this falls back to rebuilding names only when it does not.
  */
 private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
 
@@ -29,14 +35,37 @@ private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
   def checkAvailable(clazz: Class[_]): Unit = ()
 
   /**
+   * True when the hierarchy `clazz` belongs to derives [[SealedSubtypes]], which marks it as surely
+   * as extending the marker trait does.
+   */
+  def isDerived(clazz: Class[_]): Boolean = derivedRootOf(clazz).isDefined
+
+  // the whole supertype graph: an implementation may sit below an intermediate sealed trait, and it
+  // is the root of the hierarchy that derived the table
+  private def derivedRootOf(clazz: Class[_]): Option[Class[_]] =
+    if (derivedTable(clazz).isDefined) Some(clazz)
+    else supertypesOf(clazz).view.flatMap(derivedRootOf).headOption
+
+  /**
    * Scala 3 cannot enumerate a hierarchy, so a subclass can only be ruled out where the JVM proves
    * it: a final class, which covers the module class of every `case object`. A `case class` is not
    * final in bytecode and can be extended by a plain class, so it cannot be ruled out here - Scala 2
    * answers the same question exactly, from the hierarchy itself.
    */
-  def mayHaveSubtypes(clazz: Class[_], root: Class[_]): Boolean = !Modifier.isFinal(clazz.getModifiers)
+  def mayHaveSubtypes(clazz: Class[_], root: Class[_]): Boolean = derivedTable(root) match {
+    case Some(table) => table.exists(entry => entry.clazz != clazz && clazz.isAssignableFrom(entry.clazz))
+    case None => !Modifier.isFinal(clazz.getModifiers)
+  }
 
-  def findSubtype(baseClass: Class[_], root: Class[_], typeName: String): Option[Subtype] = {
+  def findSubtype(baseClass: Class[_], root: Class[_], typeName: String): Option[Subtype] =
+    derivedTable(root) match {
+      case Some(table) =>
+        table.find(entry => polymorphism.typeNameFor(entry.clazz, root) == typeName)
+          .filter(entry => baseClass.isAssignableFrom(entry.clazz))
+      case None => findByName(baseClass, root, typeName)
+    }
+
+  private def findByName(baseClass: Class[_], root: Class[_], typeName: String): Option[Subtype] = {
     val loader = loaderFor(baseClass)
     // anchored on the root, so a property declared as an intermediate type still resolves the names
     // that were written for the hierarchy as a whole
@@ -59,6 +88,14 @@ private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
    */
   def unreachableReason(clazz: Class[_], root: Class[_]): Option[String] = {
     val typeName = polymorphism.typeNameFor(clazz, root)
+    // a derived table names the whole hierarchy at once, so a name claimed twice is caught from
+    // either side rather than only from whichever implementation resolution did not reach
+    derivedTable(root).foreach { table =>
+      val clashing = table.filter(entry => polymorphism.typeNameFor(entry.clazz, root) == typeName)
+      if (clashing.length > 1) {
+        return clashing.find(_.clazz != clazz).map(entry => nameTakenMessage(clazz, typeName, entry.clazz))
+      }
+    }
     polymorphism.resolve(root, root, typeName) match {
       case Some(subtype) if subtype.clazz == clazz => None
       case Some(subtype) => Some(nameTakenMessage(clazz, typeName, subtype.clazz))
@@ -78,6 +115,34 @@ private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
     prefixesFor(rootName).flatMap(prefix => Seq(prefix + jvm + "$", prefix + jvm))
   }
 
-  /** Nothing is cached here - resolution is memoised on the SealedPolymorphism instance. */
-  def clearCache(): Unit = ()
+  /**
+   * The table a hierarchy captured by deriving [[SealedSubtypes]], read off its companion. The
+   * compiler puts a `derived$SealedSubtypes` there, which is the only trace of it at runtime.
+   */
+  private def derivedTable(root: Class[_]): Option[Seq[Subtype]] = {
+    val cache = _derived
+    Option(cache.get(root)) match {
+      case Some(table) => table
+      case _ =>
+        val table = readDerivedTable(root)
+        Option(cache.putIfAbsent(root, table)).getOrElse(table)
+    }
+  }
+
+  private def readDerivedTable(root: Class[_]): Option[Seq[Subtype]] = {
+    Try {
+      val companion = Class.forName(root.getName + "$", true, loaderFor(root))
+      val module = companion.getField("MODULE$").get(None.orNull)
+      val derived = companion.getMethod(DerivedMethodName).invoke(module).asInstanceOf[SealedSubtypes[_]]
+      derived.subtypes.map { case (clazz, singleton) => Subtype(clazz, singleton) }
+    }.toOption
+  }
+
+  private val DerivedMethodName = "derived$" + classOf[SealedSubtypes[_]].getSimpleName
+
+  // bounded for the same reason as the other caches in this package
+  @volatile private var _derived: LookupCache[Class[_], Option[Seq[Subtype]]] =
+    DefaultLookupCacheFactory.createLookupCache(16, 1000)
+
+  def clearCache(): Unit = _derived.clear()
 }

--- a/src/main/scala/tools/jackson/module/scala/util/SealedPolymorphism.scala
+++ b/src/main/scala/tools/jackson/module/scala/util/SealedPolymorphism.scala
@@ -87,6 +87,10 @@ private[scala] object SealedPolymorphism {
     prefixes.result().distinct
   }
 
+  /** What a type directly extends, stopping at `AnyRef` since nothing above it can be marked. */
+  private[scala] def supertypesOf(clazz: Class[_]): Seq[Class[_]] =
+    (Option(clazz.getSuperclass).toSeq ++ clazz.getInterfaces).filter(_ != classOf[AnyRef])
+
   private[scala] def moduleInstance(clazz: Class[_]): Option[AnyRef] =
     Try(clazz.getField(ModuleFieldName).get(None.orNull)).toOption.map(_.asInstanceOf[AnyRef])
 
@@ -124,17 +128,12 @@ private[scala] class SealedPolymorphism {
    * time rather than remembered - two mappers sharing a module must not see each other's.
    */
   def isMarked(clazz: Class[_], config: MixInResolver): Boolean =
-    MarkerClass.isAssignableFrom(clazz) || markedByMixin(clazz, config)
+    MarkerClass.isAssignableFrom(clazz) || markedByMixin(clazz, config) || lookup.isDerived(clazz)
 
-  private def markedByMixin(clazz: Class[_], config: MixInResolver): Boolean = {
-    var current: Class[_] = clazz
-    var found = false
-    while (!found && current != null && current != classOf[AnyRef]) {
-      found = mixinMarks(current, config) || current.getInterfaces.exists(mixinMarks(_, config))
-      current = current.getSuperclass
-    }
-    found
-  }
+  // the whole supertype graph, not just what each superclass implements directly: an
+  // implementation may sit below an intermediate trait that is what the mix-in was put on
+  private def markedByMixin(clazz: Class[_], config: MixInResolver): Boolean =
+    mixinMarks(clazz, config) || supertypesOf(clazz).exists(markedByMixin(_, config))
 
   private def mixinMarks(clazz: Class[_], config: MixInResolver): Boolean = {
     val mixin = config.findMixInClassFor(clazz)
@@ -158,8 +157,7 @@ private[scala] class SealedPolymorphism {
   }
 
   private def markedParentOf(clazz: Class[_], config: MixInResolver): Option[Class[_]] =
-    (Option(clazz.getSuperclass).toSeq ++ clazz.getInterfaces)
-      .find(parent => parent != MarkerClass && isMarked(parent, config))
+    supertypesOf(clazz).find(parent => parent != MarkerClass && isMarked(parent, config))
 
   /**
    * The name written to `@type`: the implementation's class name with the longest prefix shared

--- a/src/test/scala-3/tools/jackson/module/scala/poly/DerivesSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/poly/DerivesSpec.scala
@@ -1,0 +1,54 @@
+package tools.jackson.module.scala.poly
+
+import tools.jackson.core.`type`.TypeReference
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.{DefaultScalaModule, SealedSubtypes}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// marked by deriving rather than by extending the marker trait
+sealed trait Beast derives SealedSubtypes
+case class Wolf(name: String) extends Beast
+case object Phantom extends Beast
+sealed trait Winged extends Beast
+case class Raven(feathers: Int) extends Winged
+object Kept { case class Tame(name: String) extends Beast }
+
+case class Lair(beast: Beast)
+
+class DerivesSpec extends AnyWordSpec with Matchers {
+  private val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
+
+  private def roundTrip[T](value: T, clazz: Class[T]): T = mapper.readValue(mapper.writeValueAsString(value), clazz)
+
+  "SealedSubtypes" should {
+    "mark a hierarchy the way the marker trait does" in {
+      mapper.writeValueAsString(Lair(Wolf("grey"))) shouldEqual """{"beast":{"@type":"Wolf","name":"grey"}}"""
+      mapper.writeValueAsString(Lair(Phantom)) shouldEqual """{"beast":{"@type":"Phantom"}}"""
+    }
+    "round trip every shape of implementation" in {
+      roundTrip(Lair(Wolf("grey")), classOf[Lair]) shouldEqual Lair(Wolf("grey"))
+      roundTrip(Lair(Phantom), classOf[Lair]).beast should be theSameInstanceAs Phantom
+      roundTrip(Lair(Raven(7)), classOf[Lair]) shouldEqual Lair(Raven(7))
+    }
+    "reach an implementation through an intermediate sealed trait" in {
+      mapper.writeValueAsString(Lair(Raven(7))) shouldEqual """{"beast":{"@type":"Raven","feathers":7}}"""
+    }
+    "name an implementation declared in another object the same way" in {
+      mapper.writeValueAsString(Lair(Kept.Tame("cat"))) shouldEqual """{"beast":{"@type":"Kept.Tame","name":"cat"}}"""
+      roundTrip(Lair(Kept.Tame("cat")), classOf[Lair]) shouldEqual Lair(Kept.Tame("cat"))
+    }
+    "read the base type at the top level" in {
+      mapper.readValue("""{"@type":"Wolf","name":"grey"}""", classOf[Beast]) shouldEqual Wolf("grey")
+    }
+    "deserialize into a collection of the base type" in {
+      val json = """[{"@type":"Wolf","name":"grey"},{"@type":"Phantom"}]"""
+      mapper.readValue(json, new TypeReference[List[Beast]] {}) shouldEqual List(Wolf("grey"), Phantom)
+    }
+    "reject a @type that names something outside the hierarchy" in {
+      intercept[IllegalArgumentException] {
+        mapper.readValue("""{"@type":"Dog","name":"rex"}""", classOf[Beast])
+      }
+    }
+  }
+}

--- a/src/test/scala/tools/jackson/module/scala/poly/MixinFixtures.scala
+++ b/src/test/scala/tools/jackson/module/scala/poly/MixinFixtures.scala
@@ -5,5 +5,8 @@ sealed trait Vehicle
 case class Car(wheels: Int) extends Vehicle
 case class Truck(axles: Int, load: String) extends Vehicle
 case object Bike extends Vehicle
+// an implementation below an intermediate trait, so the mix-in is two levels above it
+sealed trait Powered extends Vehicle
+case class Van(seats: Int) extends Powered
 
 case class Garage(vehicle: Vehicle)

--- a/src/test/scala/tools/jackson/module/scala/poly/MixinSpec.scala
+++ b/src/test/scala/tools/jackson/module/scala/poly/MixinSpec.scala
@@ -35,6 +35,11 @@ class MixinSpec extends AnyWordSpec with Matchers {
       roundTrip(Garage(Truck(3, "sand"))) shouldEqual Garage(Truck(3, "sand"))
       roundTrip(Garage(Bike)).vehicle should be theSameInstanceAs Bike
     }
+    "reach an implementation below an intermediate trait" in {
+      val mapper = mapperWith(classOf[VehicleMixin])
+      mapper.writeValueAsString(Garage(Van(3))) shouldEqual """{"vehicle":{"@type":"Van","seats":3}}"""
+      mapper.readValue(mapper.writeValueAsString(Garage(Van(3))), classOf[Garage]) shouldEqual Garage(Van(3))
+    }
     "accept an anonymous class as the mix-in" in {
       val anonymous = (new SealedPolymorphismSupport {}).getClass
       val mapper = mapperWith(anonymous)


### PR DESCRIPTION
Rebased onto `3.x` now that #839 has merged; a single commit on top of it.

```scala
sealed trait Animal derives SealedSubtypes
case class Dog(name: String) extends Animal
case object Unknown extends Animal

// {"@type":"Dog","name":"rex"}
```

Marks a hierarchy as surely as extending `SealedPolymorphismSupport`, and writes identical JSON.

## What deriving buys

Everything Scala 3 cannot work out at runtime. A macro captures the implementations while the compiler still knows them, so a Scala 3 hierarchy is **enumerated** the way scala-reflect enumerates one on Scala 2 — the gap that forced candidate-name resolution in the first place:

- an implementation somewhere name rebuilding could not reach is still found
- a name claimed twice is reported for the hierarchy, rather than only from whichever implementation resolution happened not to reach
- a subclass can be ruled out exactly, instead of only where the JVM proves the class `final`
- **a base that is not sealed is refused by the compiler** — the check Scala 3 otherwise cannot make at all, and which Scala 2 makes via `isSealed`

The derived table is exact, so it takes priority wherever it exists; rebuilding names from where the root is declared remains the fallback for a hierarchy that only extends the marker.

The macro recurses through intermediate sealed traits, captures the instance of each `case object`, and handles implementations declared in another object. Names still come from the shared rule at runtime, not from the macro, so the wire format cannot drift between the two ways of opting in.

Scala 3 only — Scala 2 already reads the same from the class file.

## A bug this uncovered, already merged

Both supertype walks — the new derived one and the **mix-in** one merged in #835 — climbed only what each superclass implements *directly*. So neither reached an implementation sitting below an intermediate trait:

```scala
sealed trait Beast derives SealedSubtypes
sealed trait Winged extends Beast
case class Raven(feathers: Int) extends Winged   // was left untagged
```

Both now walk the whole supertype graph. The mix-in half had nothing covering it; it does now (`Van` under a sealed `Powered`, with the mix-in on `Vehicle`).

## Testing

New `DerivesSpec` (7 tests, Scala 3 only) plus the mix-in regression. Scala 3 **62** poly tests, Scala 2 **55**. Full runs: 2.12 **630**, 2.13 **637**, Scala 3 **696**. mima clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01263NLDeEasXcvWEYEvLa9u

