### PR TITLE
avoid eager static initialization in Class.forName calls

### DIFF
--- a/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
+++ b/src/main/java/tools/jackson/module/scala/javadsl/ScalaModule.java
@@ -22,7 +22,8 @@ public final class ScalaModule {
      */
     public static JacksonModule enumModule() {
         try {
-            Class<?> objectClass = Class.forName("tools.jackson.module.scala.EnumModule$");
+            Class<?> objectClass = Class.forName(
+                    "tools.jackson.module.scala.EnumModule$", false, ScalaModule.class.getClassLoader());
             VarHandle varHandle = MethodHandles.publicLookup().findStaticVarHandle(
                     objectClass, "MODULE$", objectClass);
             return (JacksonModule) varHandle.get();

--- a/src/main/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
@@ -18,7 +18,7 @@ private[introspect] object DerivedTypeInfo {
   def erasedTypeArguments(clazz: Class[_]): Seq[(String, Class[_])] = {
     Try {
       val loader = Option(clazz.getClassLoader).getOrElse(ClassLoader.getSystemClassLoader)
-      val companion = Class.forName(clazz.getName + "$", true, loader)
+      val companion = Class.forName(clazz.getName + "$", false, loader)
       val instance = companion.getField("MODULE$").get(None.orNull)
       val derived = companion.getMethod(MethodName).invoke(instance).asInstanceOf[ScalaTypeInfo[_]]
       derived.erasedTypeArguments.map { case (field, argument) => (field, argument: Class[_]) }

--- a/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/Scala3EnumInfo.scala
@@ -96,7 +96,7 @@ private[scala] object Scala3EnumInfo {
 
   private def companionOf(clazz: Class[_]): Option[AnyRef] = {
     Try {
-      val companionClass = Class.forName(clazz.getName + "$", true, loaderFor(clazz))
+      val companionClass = Class.forName(clazz.getName + "$", false, loaderFor(clazz))
       companionClass.getField(ModuleFieldName).get(None.orNull)
     }.toOption
   }

--- a/src/main/scala-3/tools/jackson/module/scala/util/SubtypeLookup.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/util/SubtypeLookup.scala
@@ -131,7 +131,7 @@ private[scala] class SubtypeLookup(polymorphism: SealedPolymorphism) {
 
   private def readDerivedTable(root: Class[_]): Option[Seq[Subtype]] = {
     Try {
-      val companion = Class.forName(root.getName + "$", true, loaderFor(root))
+      val companion = Class.forName(root.getName + "$", false, loaderFor(root))
       val module = companion.getField("MODULE$").get(None.orNull)
       val derived = companion.getMethod(DerivedMethodName).invoke(module).asInstanceOf[SealedSubtypes[_]]
       derived.subtypes.map { case (clazz, singleton) => Subtype(clazz, singleton) }

--- a/src/main/scala/tools/jackson/module/scala/deser/EnumerationDeserializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/EnumerationDeserializerModule.scala
@@ -35,7 +35,8 @@ private class EnumerationDeserializer(theType: JavaType) extends ValueDeserializ
           ctxt.handleUnexpectedToken(theType, jp).asInstanceOf[Enumeration#Value]
         } else {
           jp.nextToken()
-          Class.forName(eclassName + "$").getField("MODULE$").get(None.orNull).asInstanceOf[Enumeration].withName(valueValue)
+          Class.forName(eclassName + "$", false, getClass.getClassLoader)
+            .getField("MODULE$").get(None.orNull).asInstanceOf[Enumeration].withName(valueValue)
         }
       }
     }


### PR DESCRIPTION
Every main-source `Class.forName` call now passes `initialize = false` with an explicit classloader (the same loader each site used before):

- `javadsl/ScalaModule.java` — the `EnumModule$` probe
- `util/SubtypeLookup.scala`, `util/Scala3EnumInfo.scala`, `introspect/DerivedTypeInfo.scala` (Scala 3) — companion lookups
- `deser/EnumerationDeserializerModule.scala` — the legacy enumeration deserializer

Behavior is unchanged where the loaded class is actually used: each site goes on to read `MODULE$`, and the JVM initializes the class lazily at that first static-field access. The change only stops static initializers from firing for classes that are loaded and then discarded, or when a lookup bails partway — the candidate-probing paths in `SubtypeLookup` and `Scala3EnumInfo` already used `false` for exactly that reason.

Verified on 2.13.16 and 3.3.8: main sources compile, `EnumerationDeserializerTest` passes, and the Scala 3 enum/javadsl/poly/ScalaTypeInfo/util suites pass (16 suites, 132 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)