### PR TITLE
consume a case object's JSON without eating the tokens around it

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
@@ -1,6 +1,6 @@
 package tools.jackson.module.scala.deser
 
-import tools.jackson.core.{JsonParser, JsonToken}
+import tools.jackson.core.JsonParser
 import tools.jackson.databind.JacksonModule.SetupContext
 import tools.jackson.databind.deser.Deserializers
 import tools.jackson.databind.deser.std.StdDeserializer
@@ -13,11 +13,12 @@ import scala.languageFeature.postfixOps
 
 private class ScalaObjectDeserializer(value: Any) extends StdDeserializer[Any](classOf[Any]) {
   override def deserialize(p: JsonParser, ctxt: DeserializationContext): Any = {
-    if (p.currentToken() != JsonToken.END_OBJECT) {
-      while (p.nextToken() != JsonToken.END_OBJECT) {
-        // consume the object
-      }
-    }
+    // A Scala object holds no state, so whatever was written for it is consumed and discarded.
+    // skipChildren stops at the end token matching the one it started on - not at the first one it
+    // meets - and does nothing at all for a scalar, so a nested object no longer ends the value
+    // early and a scalar no longer eats the tokens of whatever encloses it. Reading a scalar at the
+    // root used to spin forever here: nextToken returns null at end of input, never END_OBJECT.
+    p.skipChildren()
     value
   }
 }

--- a/src/test/scala/tools/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
@@ -1,6 +1,6 @@
 package tools.jackson.module.scala.deser
 
-import CaseObjectDeserializerTest.{Foo, TestObject}
+import CaseObjectDeserializerTest.{Foo, Holder, TestObject}
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.introspect.VisibilityChecker
@@ -14,6 +14,8 @@ object CaseObjectDeserializerTest {
   case object Foo {
     val field: String = "bar"
   }
+
+  case class Holder(obj: TestObject.type, after: Int)
 }
 
 class CaseObjectDeserializerTest extends DeserializerTest {
@@ -67,6 +69,36 @@ class CaseObjectDeserializerTest extends DeserializerTest {
     val json = mapper.writeValueAsString(original)
     val deserialized = mapper.readValue[TestObject.type](json)
     assert(deserialized === original)
+  }
+
+  it should "leave the tokens of the enclosing object alone" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":{},"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "skip a nested object written where a case object is expected" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":{"x":{"y":1}},"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "skip a scalar written where a case object is expected" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":5,"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "not hang on a scalar read as a case object" in {
+    // the read runs on its own thread: a regression here spins forever rather than failing, and the
+    // suite has to be able to report that instead of hanging with it
+    val mapper = newMapper
+    @volatile var result: Any = null
+    val reader = new Thread(() => result = mapper.readValue("5", TestObject.getClass))
+    reader.setDaemon(true)
+    reader.start()
+    reader.join(30000)
+    withClue("reading a scalar as a case object did not terminate: ") {
+      reader.isAlive shouldBe false
+    }
+    result shouldEqual TestObject
   }
 
   "An ObjectMapper without ScalaObjectDeserializerModule" should "deserialize a case object but create a new instance" in {


### PR DESCRIPTION
`ScalaObjectDeserializer` discarded the value written for a Scala `object` by looping until it saw an `END_OBJECT`, whichever one that turned out to be:

```scala
while (p.nextToken() != JsonToken.END_OBJECT) {}
```

Three ways that reads the wrong tokens:

| input | before | after |
|---|---|---|
| `{"obj":{"x":{"y":1}},"after":7}` | `MismatchedInputException: Trailing token` — the value ends at the *nested* `END_OBJECT` | `Holder(TestObject, 7)` |
| `{"obj":5,"after":7}` | `Holder(TestObject, 0)` — the enclosing `END_OBJECT` is consumed and `after` is silently lost | `Holder(TestObject, 7)` |
| `readValue("5", TestObject.getClass)` | **spins forever** — at the root `nextToken()` returns `null` at end of input, never `END_OBJECT` | `TestObject` |

The last one hangs a thread on input a service does not control, so it is reachable from untrusted JSON.

`skipChildren()` stops at the end token matching the one it started on rather than at the first one it meets, and does nothing at all for a scalar — which is what this code wanted in all three cases.

## Tests

Four cases added to `CaseObjectDeserializerTest`. The non-termination one runs the read on its own daemon thread and joins with a timeout, so a regression reports a failure instead of hanging the suite with it.

Full suite: 642 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)