### PR TITLE
report an Iterator as empty when it is empty, not when it is not

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -42,7 +42,8 @@ private trait IteratorSerializer
     new ResolvedIteratorSerializer(this, property, vts, elementSerializer, unwrapSingle,
       suppressableValue, suppressNulls)
 
-  override def isEmpty(serializationContext: SerializationContext, value: collection.Iterator[Any]): Boolean = value.hasNext
+  // hasNext leaves the iterator where it found it, so this is safe to ask before serializing
+  override def isEmpty(serializationContext: SerializationContext, value: collection.Iterator[Any]): Boolean = !value.hasNext
 }
 
 private class ResolvedIteratorSerializer( src: IteratorSerializer,

--- a/src/test/scala/tools/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -7,6 +7,16 @@ import org.scalatest.matchers.Matcher
 
 import scala.collection.{Iterator, immutable, mutable}
 
+class NonEmptyIterators {
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  def emptyIterator: Iterator[Int] = Iterator.empty
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  def nonEmptyIterator: Iterator[Int] = Iterator(1, 2, 3)
+}
+
 class NonEmptyCollections {
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -114,6 +124,10 @@ class IterableSerializerTest extends SerializerTest {
 
   it should "honor the JsonInclude(NON_EMPTY) annotation" in {
     serialize(new NonEmptyCollections) should be("""{"nonEmptyIterable":[1,2,3]}""")
+  }
+
+  it should "honor the JsonInclude(NON_EMPTY) annotation for Iterators" in {
+    serialize(new NonEmptyIterators) should be("""{"nonEmptyIterator":[1,2,3]}""")
   }
 
   it should "honor JsonTypeInfo" in {


### PR DESCRIPTION
`IteratorSerializer.isEmpty` returned `value.hasNext`, missing the negation:

```scala
override def isEmpty(ctx: SerializationContext, value: Iterator[Any]): Boolean = value.hasNext
```

`IterableSerializer` (`value.isEmpty`) and `ScalaIteratorSerializer` (`value.isEmpty`) beside it both answer this correctly — this one is the odd one out.

Under `@JsonInclude(NON_EMPTY)` the effect is exactly backwards: the empty `Iterator` is written and the one with elements in it is dropped.

```
{"emptyIterator":[]}            // before
{"nonEmptyIterator":[1,2,3]}    // after
```

`hasNext` leaves the iterator where it found it, so asking before serializing stays safe — no element is consumed by the check.

## Tests

`NonEmptyIterators` and a matching case in `IterableSerializerTest`, alongside the `NonEmptyCollections` one that has always covered the `Iterable` side.

Full suite: 639 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)