### PR TITLE
stop draining the Iterator to find out whether it holds one element

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -20,17 +20,37 @@ private trait IteratorSerializer
 {
   def iteratorSerializer: ScalaIteratorSerializer
 
-  override def hasSingleElement(p1: collection.Iterator[Any]): Boolean =
-    p1.size == 1
+  // An iterator cannot be counted without being consumed, so this cannot be answered without
+  // destroying the value it is asked about - the same reason databind's own IteratorSerializer
+  // answers false here. WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED is honoured in serialize instead, from a
+  // single element held back rather than from a length.
+  override def hasSingleElement(p1: collection.Iterator[Any]): Boolean = false
 
   override def serialize(value: collection.Iterator[Any], jgen: JsonGenerator, serializationContext: SerializationContext): Unit = {
-    if (serializationContext.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED) && hasSingleElement(value)) {
-      iteratorSerializer.serializeContents(value, jgen, serializationContext)
+    if (serializationContext.isEnabled(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)) {
+      serializeUnwrappingSingle(value, jgen, serializationContext)
     } else {
-      jgen.writeStartArray(value)
-      iteratorSerializer.serializeContents(value, jgen, serializationContext)
-      jgen.writeEndArray()
+      writeArray(value, jgen, serializationContext)
     }
+  }
+
+  // Pulls one element to find out whether a second follows, then serializes that element and the
+  // rest of the iterator together - so nothing is lost whichever way the answer goes.
+  private def serializeUnwrappingSingle(value: collection.Iterator[Any], jgen: JsonGenerator,
+                                        serializationContext: SerializationContext): Unit = {
+    if (!value.hasNext) writeArray(value, jgen, serializationContext)
+    else {
+      val first = value.next()
+      if (value.hasNext) writeArray(Iterator.single(first) ++ value, jgen, serializationContext)
+      else iteratorSerializer.serializeContents(Iterator.single(first), jgen, serializationContext)
+    }
+  }
+
+  private def writeArray(value: collection.Iterator[Any], jgen: JsonGenerator,
+                         serializationContext: SerializationContext): Unit = {
+    jgen.writeStartArray(value)
+    iteratorSerializer.serializeContents(value, jgen, serializationContext)
+    jgen.writeEndArray()
   }
 
   override def serializeContents(value: collection.Iterator[Any], gen: JsonGenerator, serializationContext: SerializationContext): Unit = {

--- a/src/main/scala/tools/jackson/module/scala/ser/ScalaIteratorSerializer.scala
+++ b/src/main/scala/tools/jackson/module/scala/ser/ScalaIteratorSerializer.scala
@@ -32,7 +32,9 @@ private case class ScalaIteratorSerializer(elemType: JavaType, staticTyping: Boo
 
   override def isEmpty(prov: SerializationContext, value: Iterator[Any]): Boolean = value.isEmpty
 
-  override def hasSingleElement(value: Iterator[Any]): Boolean = value.size == 1
+  // counting an iterator consumes it, so the question cannot be answered here without destroying
+  // the value - see the note on serialize below
+  override def hasSingleElement(value: Iterator[Any]): Boolean = false
 
   override def serialize(value: Iterator[Any], g: JsonGenerator, serializationContext: SerializationContext): Unit = {
     //writeSingleElement is unsupported - also unsupported in tools.jackson.databind.ser.impl.IteratorSerializer

--- a/src/test/scala/tools/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -28,6 +28,16 @@ object IterableSerializerTest {
 
   case class CHolder(c: Seq[C])
 
+  // a user-written Iterator, which is resolved to a serializer by its own class rather than by the
+  // declared Iterator type
+  class Counted(elems: String*) extends Iterator[String] {
+    private val underlying = elems.iterator
+    def hasNext: Boolean = underlying.hasNext
+    def next(): String = underlying.next()
+  }
+
+  case class IteratorHolder(it: Iterator[String])
+
 }
 
 class IterableSerializerTest extends SerializerTest {
@@ -125,6 +135,26 @@ class IterableSerializerTest extends SerializerTest {
       .build()
     mapper.writeValueAsString(Seq("123")) shouldBe """"123""""
     mapper.writeValueAsString(Seq("123", "abc")) shouldBe """["123","abc"]"""
+  }
+
+  it should "honor SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED for Iterators" in {
+    val mapper = newBuilder.enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)
+      .build()
+    mapper.writeValueAsString(new Counted("123")) shouldBe """"123""""
+    mapper.writeValueAsString(new Counted("123", "abc")) shouldBe """["123","abc"]"""
+    mapper.writeValueAsString(new Counted()) shouldBe "[]"
+  }
+
+  it should "honor SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED for Iterator properties" in {
+    val mapper = newBuilder.enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED)
+      .build()
+    mapper.writeValueAsString(IteratorHolder(new Counted("123"))) shouldBe """{"it":"123"}"""
+    mapper.writeValueAsString(IteratorHolder(new Counted("123", "abc"))) shouldBe """{"it":["123","abc"]}"""
+  }
+
+  it should "write every element of an Iterator when single elements are not unwrapped" in {
+    serialize(new Counted("123", "abc")) shouldBe """["123","abc"]"""
+    serialize(IteratorHolder(new Counted("123"))) shouldBe """{"it":["123"]}"""
   }
 
   val matchUnorderedSet: Matcher[Any] = {


### PR DESCRIPTION
`IteratorSerializer.hasSingleElement` was `p1.size == 1`, and `size` consumes the iterator it counts. `serialize` asked it whenever `WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED` was enabled, then handed the now-exhausted iterator to `serializeContents`, which found nothing left to write:

| value | before | after |
|---|---|---|
| one-element `Iterator` property | `{"it"}` — a name with no value, **not valid JSON** | `{"it":"123"}` |
| two-element `Iterator` property | `{"it":[]}` | `{"it":["123","abc"]}` |
| two-element `Iterator` at the root | `[]` | `["123","abc"]` |

So the feature silently emptied every Scala `Iterator`, and in the single-element case produced output that cannot be parsed back.

The question cannot be answered without destroying the value it is asked about — which is why databind's own `ser.jdk.IteratorSerializer` returns `false` from `hasSingleElement`. This does the same, and honours the feature in `serialize` instead: it holds one element back to see whether a second follows, then serializes that element together with the rest. The feature keeps working for iterators, and nothing is lost whichever way the answer goes.

`ScalaIteratorSerializer` carried the same `value.size == 1`. It is unreachable today only because that class overrides `serialize` without calling it, but it returns `false` now too — matching the note already on its `serialize` about `writeSingleElement` being unsupported.

## Tests

Four cases in `IterableSerializerTest`, covering the feature on and off, at the root and as a property, for zero, one and two elements. They use a user-written `Iterator` subclass, which is the shape that resolves to this serializer.

Verified failing without the main-source change (`"[]"` where `"123"` was expected, and the malformed `{"it"...}`), passing with it.

Full suite: 641 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)