### PR TITLE
close the build.properties stream

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/JacksonModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/JacksonModule.scala
@@ -17,7 +17,11 @@ object JacksonModule {
   lazy val buildProps: scala.collection.mutable.Map[String, String] = {
     val props = new Properties
     val stream = cls.getClassLoader.getResourceAsStream(buildPropsFilename)
-    if (stream ne null) props.load(stream)
+    // try/finally rather than scala.util.Using, which 2.12 does not have
+    if (stream ne null) {
+      try props.load(stream)
+      finally stream.close()
+    }
 
     props.asScala
   }

--- a/src/test/scala/tools/jackson/module/scala/DefaultScalaModuleTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/DefaultScalaModuleTest.scala
@@ -8,4 +8,11 @@ class DefaultScalaModuleTest extends BaseSpec {
     version.getArtifactId should be ("jackson-module-scala")
     version.getGroupId should be ("tools.jackson.module")
   }
+
+  it should "read the build properties the version is built from" in {
+    val props = JacksonModule.buildProps
+    props.get("groupId") should be (Some("tools.jackson.module"))
+    props.get("artifactId") should be (Some("jackson-module-scala"))
+    props.get("version") should not be empty
+  }
 }


### PR DESCRIPTION
`JacksonModule.buildProps` opened the resource and never closed it:

```scala
val stream = cls.getClassLoader.getResourceAsStream(buildPropsFilename)
if (stream ne null) props.load(stream)
```

It also leaked the handle outright if `Properties.load` threw part way through.

It is a `lazy val` read once per process, so the cost is one descriptor rather than a growing leak — but it is the only unclosed `Closeable` in the main sources, and the fix is two lines. `try`/`finally` rather than `scala.util.Using`, which 2.12 does not have.

## Tests

`DefaultScalaModuleTest` already forces `buildProps` through `DefaultScalaModule.version`; a case was added asserting the three keys `version` reads are actually there, so the loading path stays pinned.

Full suite: 639 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)