### PR TITLE
remember what a class derived, per module instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -194,5 +194,11 @@ mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.deser.EnumDeserializerModule.scala3EnumInfo"),
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.deser.EnumDeserializerModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_="),
   ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.ser.EnumSerializerModule.scala3EnumInfo"),
-  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.ser.EnumSerializerModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_=")
+  ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tools.jackson.module.scala.ser.EnumSerializerModule.tools$jackson$module$scala$Scala3EnumSupportState$_setter_$scala3EnumInfo_="),
+  // What each class captured by deriving ScalaTypeInfo is remembered on the module instance rather
+  // than in a singleton, for the same reason the enum cache above is. A trait that grows state grows
+  // the accessors the implementing class has to provide, so anyone extending this trait has to
+  // recompile - the field itself is private to the introspect package and cannot be called.
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("tools.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule._derivedTypeInfo"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("tools.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule._derivedTypeInfo_=")
 )

--- a/src/main/scala-2.+/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
+++ b/src/main/scala-2.+/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
@@ -1,9 +1,14 @@
 package tools.jackson.module.scala.introspect
 
+import tools.jackson.module.scala.LookupCacheFactory
+
 /**
  * Deriving what the JVM erases is a Scala 3 way of capturing it, so there is nothing to read here.
  * Scala 2 users register the same thing with `registerReferencedValueType`.
+ *
+ * Nothing is read, so nothing is cached and the factory goes unused. It is taken all the same, so
+ * that the introspector builds this the same way whichever compiler it was built with.
  */
-private[introspect] object DerivedTypeInfo {
+private[introspect] class DerivedTypeInfo(lookupCacheFactory: LookupCacheFactory) {
   def erasedTypeArguments(clazz: Class[_]): Seq[(String, Class[_])] = Seq.empty
 }

--- a/src/main/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfo.scala
@@ -1,6 +1,7 @@
 package tools.jackson.module.scala.introspect
 
-import tools.jackson.module.scala.ScalaTypeInfo
+import tools.jackson.databind.util.LookupCache
+import tools.jackson.module.scala.{LookupCacheFactory, ScalaTypeInfo}
 
 import scala.util.Try
 
@@ -10,12 +11,41 @@ import scala.util.Try
  * A `derives` leaves nothing on the class itself - no parent, no annotation - so the companion is
  * what marks it: the compiler puts a `derived$ScalaTypeInfo` there, and that is the only trace of it
  * at runtime.
+ *
+ * One of these belongs to each [[ScalaAnnotationIntrospectorModule]] instance, so a module built
+ * through [[tools.jackson.module.scala.ScalaModule.Builder]] remembers what it has read
+ * independently of every other module and of the `ScalaAnnotationIntrospectorModule` object.
  */
-private[introspect] object DerivedTypeInfo {
+private[introspect] class DerivedTypeInfo(lookupCacheFactory: LookupCacheFactory) {
 
-  private val MethodName = "derived$" + classOf[ScalaTypeInfo[_]].getSimpleName
+  import DerivedTypeInfo._
 
+  // Bounded for the same reason as the other caches that key on Class: a class loaded by a child
+  // classloader (hot redeploy, OSGi, script engines) is not retained indefinitely. Keyed by Class
+  // rather than by class name because the table holds Class instances - two same-named classes from
+  // different classloaders must not share an entry. A pure memo, so an evicted entry is read again.
+  private val cache: LookupCache[Class[_], Seq[(String, Class[_])]] =
+    lookupCacheFactory.createLookupCache(16, CacheSize)
+
+  /**
+   * What `clazz` captured by deriving [[ScalaTypeInfo]], or an empty table where it derived nothing.
+   *
+   * Asked once per bean descriptor built, so asked again for every class whose descriptor has since
+   * been evicted - the descriptor cache holds 100 by default - and answered the same way every time.
+   * The answer is therefore remembered, because reading it is not free: the great majority of classes
+   * have no companion at all, and finding that out costs a `Class.forName` that ends in a
+   * `ClassNotFoundException`, stack trace and all.
+   */
   def erasedTypeArguments(clazz: Class[_]): Seq[(String, Class[_])] = {
+    Option(cache.get(clazz)) match {
+      case Some(arguments) => arguments
+      case _ =>
+        val arguments = readErasedTypeArguments(clazz)
+        Option(cache.putIfAbsent(clazz, arguments)).getOrElse(arguments)
+    }
+  }
+
+  private def readErasedTypeArguments(clazz: Class[_]): Seq[(String, Class[_])] = {
     Try {
       val loader = Option(clazz.getClassLoader).getOrElse(ClassLoader.getSystemClassLoader)
       val companion = Class.forName(clazz.getName + "$", false, loader)
@@ -24,4 +54,9 @@ private[introspect] object DerivedTypeInfo {
       derived.erasedTypeArguments.map { case (field, argument) => (field, argument: Class[_]) }
     }.getOrElse(Seq.empty)
   }
+}
+
+private[introspect] object DerivedTypeInfo {
+  private val MethodName = "derived$" + classOf[ScalaTypeInfo[_]].getSimpleName
+  private val CacheSize = 1000
 }

--- a/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -291,6 +291,11 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
   private[introspect] var _scalaTypeCache: LookupCache[String, Boolean] =
     _lookupCacheFactory.createLookupCache(16, _scalaTypeCacheSize)
 
+  // What each class captured by deriving ScalaTypeInfo. Belongs to this module instance like the
+  // caches above it, so a module built through ScalaModule.Builder remembers what it has read
+  // independently of every other module.
+  private[introspect] var _derivedTypeInfo: DerivedTypeInfo = new DerivedTypeInfo(_lookupCacheFactory)
+
   /**
    * jackson-module-scala does not always properly handle deserialization of Options or Collections wrapping
    * Scala primitives (eg Int, Long, Boolean).
@@ -344,7 +349,7 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
    * A registration made by hand is deliberate, and is left alone.
    */
   private[introspect] def registerDerivedReferencedValueTypes(clazz: Class[_]): Unit = {
-    DerivedTypeInfo.erasedTypeArguments(clazz).foreach { case (fieldName, referencedType) =>
+    _derivedTypeInfo.erasedTypeArguments(clazz).foreach { case (fieldName, referencedType) =>
       if (getRegisteredReferencedValueType(clazz, fieldName).isEmpty) {
         registerReferencedValueType(clazz, fieldName, referencedType)
       }
@@ -390,6 +395,7 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
     _lookupCacheFactory = lookupCacheFactory
     recreateDescriptorCache()
     recreateScalaTypeCache()
+    recreateDerivedTypeInfo()
   }
 
   /**
@@ -449,6 +455,10 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
   private def recreateScalaTypeCache(): Unit = {
     _scalaTypeCache.clear()
     _scalaTypeCache = _lookupCacheFactory.createLookupCache(16, _scalaTypeCacheSize)
+  }
+
+  private def recreateDerivedTypeInfo(): Unit = {
+    _derivedTypeInfo = new DerivedTypeInfo(_lookupCacheFactory)
   }
 
 }

--- a/src/test/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfoSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/introspect/DerivedTypeInfoSpec.scala
@@ -1,0 +1,49 @@
+package tools.jackson.module.scala.introspect
+
+import tools.jackson.databind.util.LookupCache
+import tools.jackson.module.scala.{DefaultLookupCacheFactory, LookupCacheFactory, ScalaTypeInfo}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+case class DerivedFields(aLong: Option[Long], aStr: Option[String]) derives ScalaTypeInfo
+
+case class PlainFields(aLong: Option[Long])
+
+class DerivedTypeInfoSpec extends AnyWordSpec with Matchers {
+
+  private def derivedTypeInfo = new DerivedTypeInfo(DefaultLookupCacheFactory)
+
+  "DerivedTypeInfo" should {
+    "read the table a class captured" in {
+      derivedTypeInfo.erasedTypeArguments(classOf[DerivedFields]).toMap shouldEqual
+        Map("aLong" -> classOf[Long])
+    }
+    "answer with an empty table for a class that derived nothing" in {
+      derivedTypeInfo.erasedTypeArguments(classOf[PlainFields]) shouldBe empty
+    }
+    // reading the table builds a fresh Seq every time, so the same instance coming back is the memo
+    // answering rather than the companion being read again
+    "read the table once and remember it" in {
+      val info = derivedTypeInfo
+      val first = info.erasedTypeArguments(classOf[DerivedFields])
+      first should not be empty
+      info.erasedTypeArguments(classOf[DerivedFields]) should be theSameInstanceAs first
+    }
+    "keep what it remembered to itself" in {
+      val first = derivedTypeInfo.erasedTypeArguments(classOf[DerivedFields])
+      derivedTypeInfo.erasedTypeArguments(classOf[DerivedFields]) should not be
+        theSameInstanceAs(first)
+    }
+    "build its cache with the factory it was given" in {
+      var created = 0
+      val factory = new LookupCacheFactory {
+        override def createLookupCache[K, V](initialEntries: Int, maxEntries: Int): LookupCache[K, V] = {
+          created += 1
+          DefaultLookupCacheFactory.createLookupCache(initialEntries, maxEntries)
+        }
+      }
+      new DerivedTypeInfo(factory)
+      created shouldEqual 1
+    }
+  }
+}

--- a/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
+++ b/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
@@ -1,7 +1,7 @@
 package tools.jackson.module.scala.introspect
 
 import tools.jackson.databind.json.JsonMapper
-import tools.jackson.module.scala.ScalaModule
+import tools.jackson.module.scala.{DefaultLookupCacheFactory, ScalaModule}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -21,6 +21,20 @@ class ScalaAnnotationIntrospectorStateSpec extends AnyWordSpec with Matchers {
         theSameInstanceAs(second.scalaAnnotationIntrospectorModule)
       first.scalaAnnotationIntrospectorModule should not be
         theSameInstanceAs(ScalaAnnotationIntrospectorModule)
+    }
+    "give each builder its own record of what classes derived" in {
+      val first = ScalaModule.builder()
+      val second = ScalaModule.builder()
+      first.scalaAnnotationIntrospectorModule._derivedTypeInfo should not be
+        theSameInstanceAs(second.scalaAnnotationIntrospectorModule._derivedTypeInfo)
+      first.scalaAnnotationIntrospectorModule._derivedTypeInfo should not be
+        theSameInstanceAs(ScalaAnnotationIntrospectorModule._derivedTypeInfo)
+    }
+    "rebuild that record when the lookup cache factory is replaced" in {
+      val module = ScalaAnnotationIntrospectorModule.newStandaloneInstance()
+      val before = module._derivedTypeInfo
+      module.setLookupCacheFactory(DefaultLookupCacheFactory)
+      module._derivedTypeInfo should not be theSameInstanceAs(before)
     }
     "keep a referenced value type registration to the builder it was made on" in {
       val builder = ScalaModule.builder().addAllBuiltinModules()


### PR DESCRIPTION
`registerDerivedReferencedValueTypes` asks `DerivedTypeInfo` what a class captured once per bean descriptor built — so again for every class whose descriptor has since been evicted, and `_descriptorCache` holds 100 entries by default. The answer never changes between calls, and reading it is not free:

```scala
val companion = Class.forName(clazz.getName + "$", false, loader)
```

The great majority of classes have no companion at all, and finding that out costs a `Class.forName` that ends in a `ClassNotFoundException` — stack trace and all — on every miss. An application with more Scala classes in rotation than the descriptor cache holds pays it over and over.

## Where the memo lives

`DerivedTypeInfo` becomes a class holding that memo, and `ScalaAnnotationIntrospectorModule` holds one — built through the module's own `LookupCacheFactory` and rebuilt when `setLookupCacheFactory` replaces it, sitting beside `_descriptorCache` and `_scalaTypeCache`, which belong to the instance the same way. A module built through `ScalaModule.Builder` therefore remembers what it has read independently of every other module and of the `ScalaAnnotationIntrospectorModule` object, as the enum (#837) and sealed hierarchy state already do.

The cache is shaped like the other lookups in the module that key on `Class` — `SubtypeLookup`'s derived table and `Scala3EnumInfo`'s case table:

- bounded at 1000, so a class loaded by a child classloader (hot redeploy, OSGi, script engines) is not retained indefinitely, and an evicted entry is simply read again;
- keyed by `Class` rather than by class name, because the table holds `Class` instances and two same-named classes from different loaders must not share an entry.

Scala 2 gets the same class with the same constructor, so the introspector builds it the same way whichever compiler it was built with. It reads nothing and so caches nothing, exactly as before.

## Binary compatibility

Holding state in a trait means accessors the implementing class has to provide, so `_derivedTypeInfo` is a `ReversedMissingMethodProblem` for anyone extending `ScalaAnnotationIntrospectorModule`. That is the same tradeoff #837 made when it moved the enum cache onto the module instance, and it is filtered the same way, with the reasoning recorded next to those filters. The field is `private[introspect]` and cannot be called from outside the module.

## Tests

`DerivedTypeInfoSpec` in the Scala 3 test tree covers the derived table, the empty answer for a class that derived nothing, the memo itself, that two instances do not share what they remembered, and that the cache is built through the factory it was handed. Reading the table builds a fresh `Seq` every time, so asserting the same instance comes back proves the companion is not read twice — verified failing when the memo is bypassed.

`ScalaAnnotationIntrospectorStateSpec` gains two cases in the shared tree: each builder gets its own record, and replacing the lookup cache factory rebuilds it.

Scala 3.3.8: 719 passed, 0 failed. Scala 2.13.18: 649 passed, 0 failed. MiMa clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)