### PR TITLE
add DurationModule, and put it in the default modules

### DIFF
--- a/src/main/scala-2.+/tools/jackson/module/scala/DefaultScalaModule.scala
+++ b/src/main/scala-2.+/tools/jackson/module/scala/DefaultScalaModule.scala
@@ -32,7 +32,8 @@ class DefaultScalaModule extends JacksonModule {
       ScalaAnnotationIntrospectorModule.getInitializers(config) ++
       UntypedObjectDeserializerModule.getInitializers(config) ++
       EitherModule.getInitializers(config) ++
-      SymbolModule.getInitializers(config)
+      SymbolModule.getInitializers(config) ++
+      DurationModule.getInitializers(config)
   }
 }
 

--- a/src/main/scala-2.12/tools/jackson/module/scala/util/DurationConverters.scala
+++ b/src/main/scala-2.12/tools/jackson/module/scala/util/DurationConverters.scala
@@ -1,0 +1,57 @@
+package tools.jackson.module.scala.util
+
+import java.time.temporal.ChronoUnit
+import java.time.{Duration => JavaDuration}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+/**
+ * Converts between a Scala [[FiniteDuration]] and a Java [[java.time.Duration]].
+ *
+ * Scala 2.13 added these to the standard library as `scala.jdk.DurationConverters`, which the 2.13
+ * and Scala 3 builds call instead of this. Scala 2.12 has no `scala.jdk` package at all - there the
+ * conversions live in scala-java8-compat, a dependency this module does not want for two methods,
+ * so just those two are copied from `scala.jdk.javaapi.DurationConverters` (Apache 2.0, Copyright
+ * EPFL and Lightbend, Inc.).
+ *
+ * Copied rather than rewritten: the same overflow check, the same exception, the same answers. The
+ * tests run on all three builds, so this is held to what the standard library actually does.
+ */
+private[scala] object DurationConverters {
+
+  def toJava(duration: FiniteDuration): JavaDuration = {
+    if (duration.length == 0) JavaDuration.ZERO
+    else duration.unit match {
+      case TimeUnit.NANOSECONDS => JavaDuration.ofNanos(duration.length)
+      case TimeUnit.MICROSECONDS => JavaDuration.of(duration.length, ChronoUnit.MICROS)
+      case TimeUnit.MILLISECONDS => JavaDuration.ofMillis(duration.length)
+      case TimeUnit.SECONDS => JavaDuration.ofSeconds(duration.length)
+      case TimeUnit.MINUTES => JavaDuration.ofMinutes(duration.length)
+      case TimeUnit.HOURS => JavaDuration.ofHours(duration.length)
+      case TimeUnit.DAYS => JavaDuration.ofDays(duration.length)
+    }
+  }
+
+  def toScala(duration: JavaDuration): FiniteDuration = {
+    val originalSeconds = duration.getSeconds
+    val originalNanos = duration.getNano
+    if (originalNanos == 0) {
+      if (originalSeconds == 0) Duration.Zero else FiniteDuration(originalSeconds, TimeUnit.SECONDS)
+    } else if (originalSeconds == 0) {
+      FiniteDuration(originalNanos.toLong, TimeUnit.NANOSECONDS)
+    } else {
+      try {
+        val secondsAsNanos = Math.multiplyExact(originalSeconds, 1000000000L)
+        val totalNanos = secondsAsNanos + originalNanos
+        if ((totalNanos < 0 && secondsAsNanos < 0) || (totalNanos > 0 && secondsAsNanos > 0)) {
+          FiniteDuration(totalNanos, TimeUnit.NANOSECONDS)
+        } else {
+          throw new ArithmeticException()
+        }
+      } catch {
+        case _: ArithmeticException =>
+          throw new IllegalArgumentException(s"Java duration $duration cannot be expressed as a Scala duration")
+      }
+    }
+  }
+}

--- a/src/main/scala-2.13/tools/jackson/module/scala/util/DurationConverters.scala
+++ b/src/main/scala-2.13/tools/jackson/module/scala/util/DurationConverters.scala
@@ -1,0 +1,20 @@
+package tools.jackson.module.scala.util
+
+import java.time.{Duration => JavaDuration}
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.{DurationConverters => JdkDurationConverters}
+
+/**
+ * Converts between a Scala [[FiniteDuration]] and a Java [[java.time.Duration]].
+ *
+ * Scala 2.13 added these to the standard library, so there is nothing to do here but call them.
+ * The 2.12 build carries its own copy of the same conversions.
+ */
+private[scala] object DurationConverters {
+
+  def toScala(duration: JavaDuration): FiniteDuration =
+    JdkDurationConverters.JavaDurationOps(duration).toScala
+
+  def toJava(duration: FiniteDuration): JavaDuration =
+    JdkDurationConverters.ScalaDurationOps(duration).toJava
+}

--- a/src/main/scala-3/tools/jackson/module/scala/DefaultScalaModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/DefaultScalaModule.scala
@@ -33,7 +33,8 @@ class DefaultScalaModule extends JacksonModule {
       ScalaAnnotationIntrospectorModule.getInitializers(config) ++
       UntypedObjectDeserializerModule.getInitializers(config) ++
       EitherModule.getInitializers(config) ++
-      SymbolModule.getInitializers(config)
+      SymbolModule.getInitializers(config) ++
+      DurationModule.getInitializers(config)
   }
 }
 

--- a/src/main/scala/tools/jackson/module/scala/DurationModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/DurationModule.scala
@@ -1,0 +1,31 @@
+package tools.jackson.module.scala
+
+import tools.jackson.databind.JacksonModule.SetupContext
+import tools.jackson.module.scala.deser.DurationDeserializerModule
+import tools.jackson.module.scala.ser.DurationSerializerModule
+
+/**
+ * Adds support for `scala.concurrent.duration.FiniteDuration`, as a value and as a map key.
+ *
+ * A FiniteDuration is converted to and from a `java.time.Duration`, which databind then reads and
+ * writes - so a duration is formatted by whatever the mapper's `DateTimeFeature` settings say, as a
+ * timestamp or as an ISO-8601 period, exactly as a Java duration would be.
+ *
+ * Without this, a FiniteDuration is written as whatever its fields happen to be in the Scala version
+ * in use - `{"length":7,"unit":"DAYS","finite":true}` - which differs between releases and cannot
+ * reliably be read back.
+ *
+ * Derived from https://github.com/pjfanning/jackson-module-scala-duration.
+ *
+ * @since 3.3.0
+ */
+trait DurationModule extends DurationSerializerModule with DurationDeserializerModule {
+  override def getModuleName: String = "DurationModule"
+
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
+    DurationSerializerModule.getInitializers(config) ++
+      DurationDeserializerModule.getInitializers(config)
+  }
+}
+
+object DurationModule extends DurationModule

--- a/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ScalaModule.scala
@@ -92,6 +92,7 @@ object ScalaModule {
       addModule(UntypedObjectDeserializerModule)
       addModule(EitherModule)
       addModule(SymbolModule)
+      addModule(DurationModule)
       // this builder's own instance, so a built module keeps its own polymorphism state
       addModule(sealedPolymorphismModule)
       BuiltinModules.addScalaVersionSpecificModules(this)

--- a/src/main/scala/tools/jackson/module/scala/deser/DurationDeserializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/DurationDeserializerModule.scala
@@ -1,0 +1,70 @@
+package tools.jackson.module.scala.deser
+
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.JacksonModule.SetupContext
+import tools.jackson.databind._
+import tools.jackson.databind.`type`.SimpleType
+import tools.jackson.databind.deser.std.StdDeserializer
+import tools.jackson.databind.deser.{Deserializers, KeyDeserializers}
+import tools.jackson.module.scala.JacksonModule.InitializerBuilder
+import tools.jackson.module.scala.util.DurationConverters
+import tools.jackson.module.scala.{JacksonModule, ScalaModule}
+
+import java.time.{Duration => JavaDuration}
+import scala.concurrent.duration.FiniteDuration
+
+private object FiniteDurationDeserializerShared {
+  private[deser] val JavaDurationClass = classOf[JavaDuration]
+  private[deser] lazy val JavaDurationType = SimpleType.constructUnsafe(JavaDurationClass)
+  private[deser] val FiniteDurationClass = classOf[FiniteDuration]
+}
+
+// databind reads the Java duration, so whatever it accepts - a timestamp, an ISO-8601 period - is
+// what a FiniteDuration can be read from.
+private object FiniteDurationDeserializer extends StdDeserializer[FiniteDuration](classOf[FiniteDuration]) {
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): FiniteDuration = {
+    Option(ctxt.readValue(p, FiniteDurationDeserializerShared.JavaDurationClass)) match {
+      case Some(duration) => DurationConverters.toScala(duration)
+      case _ => None.orNull
+    }
+  }
+}
+
+private object FiniteDurationKeyDeserializer extends KeyDeserializer {
+  override def deserializeKey(key: String, ctxt: DeserializationContext): AnyRef = {
+    val keyDeserializer = ctxt.findKeyDeserializer(FiniteDurationDeserializerShared.JavaDurationType, None.orNull)
+    DurationConverters.toScala(keyDeserializer.deserializeKey(key, ctxt).asInstanceOf[JavaDuration])
+  }
+}
+
+private class FiniteDurationDeserializerResolver(config: ScalaModule.Config) extends Deserializers.Base {
+  override def findBeanDeserializer(javaType: JavaType, deserializationConfig: DeserializationConfig,
+                                    beanDesc: BeanDescription.Supplier): ValueDeserializer[FiniteDuration] =
+    if (FiniteDurationDeserializerShared.FiniteDurationClass.isAssignableFrom(javaType.getRawClass))
+      FiniteDurationDeserializer
+    else None.orNull
+
+  override def hasDeserializerFor(deserializationConfig: DeserializationConfig, valueType: Class[_]): Boolean =
+    FiniteDurationDeserializerShared.FiniteDurationClass.isAssignableFrom(valueType)
+}
+
+private class FiniteDurationKeyDeserializerResolver(config: ScalaModule.Config) extends KeyDeserializers {
+  override def findKeyDeserializer(javaType: JavaType, deserializationConfig: DeserializationConfig,
+                                   beanDesc: BeanDescription.Supplier): KeyDeserializer =
+    if (FiniteDurationDeserializerShared.FiniteDurationClass.isAssignableFrom(javaType.getRawClass))
+      FiniteDurationKeyDeserializer
+    else None.orNull
+}
+
+trait DurationDeserializerModule extends JacksonModule {
+  override def getModuleName: String = "DurationDeserializerModule"
+
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
+    val builder = new InitializerBuilder()
+    builder += new FiniteDurationDeserializerResolver(config)
+    builder += new FiniteDurationKeyDeserializerResolver(config)
+    builder.build()
+  }
+}
+
+object DurationDeserializerModule extends DurationDeserializerModule

--- a/src/main/scala/tools/jackson/module/scala/ser/DurationSerializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/ser/DurationSerializerModule.scala
@@ -1,0 +1,62 @@
+package tools.jackson.module.scala.ser
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.JacksonModule.SetupContext
+import tools.jackson.databind._
+import tools.jackson.databind.ser.Serializers
+import tools.jackson.module.scala.JacksonModule.InitializerBuilder
+import tools.jackson.module.scala.util.DurationConverters
+import tools.jackson.module.scala.{JacksonModule, ScalaModule}
+
+import java.time.{Duration => JavaDuration}
+import scala.concurrent.duration.FiniteDuration
+
+private object FiniteDurationSerializerShared {
+  private[ser] val FiniteDurationClass = classOf[FiniteDuration]
+  private[ser] val JavaDurationClass = classOf[JavaDuration]
+}
+
+// The Java duration is handed to databind rather than written here, so a duration is formatted by
+// whatever the mapper's DateTimeFeature settings say - as a timestamp, or as an ISO-8601 period.
+private object FiniteDurationSerializer extends ValueSerializer[FiniteDuration] {
+  override def serialize(value: FiniteDuration, jgen: JsonGenerator, serializationContext: SerializationContext): Unit = {
+    serializationContext.writeValue(jgen, DurationConverters.toJava(value))
+  }
+}
+
+private object FiniteDurationKeySerializer extends ValueSerializer[FiniteDuration] {
+  override def serialize(value: FiniteDuration, jgen: JsonGenerator, serializationContext: SerializationContext): Unit = {
+    val keySerializer = serializationContext.findKeySerializer(FiniteDurationSerializerShared.JavaDurationClass, None.orNull)
+    keySerializer.serialize(DurationConverters.toJava(value), jgen, serializationContext)
+  }
+}
+
+private class FiniteDurationSerializerResolver(config: ScalaModule.Config) extends Serializers.Base {
+  override def findSerializer(serializationConfig: SerializationConfig, javaType: JavaType,
+                              beanDesc: BeanDescription.Supplier, formatOverrides: JsonFormat.Value): ValueSerializer[FiniteDuration] =
+    if (FiniteDurationSerializerShared.FiniteDurationClass.isAssignableFrom(javaType.getRawClass))
+      FiniteDurationSerializer
+    else None.orNull
+}
+
+private class FiniteDurationKeySerializerResolver(config: ScalaModule.Config) extends Serializers.Base {
+  override def findSerializer(serializationConfig: SerializationConfig, javaType: JavaType,
+                              beanDesc: BeanDescription.Supplier, formatOverrides: JsonFormat.Value): ValueSerializer[FiniteDuration] =
+    if (FiniteDurationSerializerShared.FiniteDurationClass.isAssignableFrom(javaType.getRawClass))
+      FiniteDurationKeySerializer
+    else None.orNull
+}
+
+trait DurationSerializerModule extends JacksonModule {
+  override def getModuleName: String = "DurationSerializerModule"
+
+  override def getInitializers(config: ScalaModule.Config): Seq[SetupContext => Unit] = {
+    val builder = new InitializerBuilder()
+    builder += new FiniteDurationSerializerResolver(config)
+    builder.addKeySerializers(new FiniteDurationKeySerializerResolver(config))
+    builder.build()
+  }
+}
+
+object DurationSerializerModule extends DurationSerializerModule

--- a/src/test/scala/tools/jackson/module/scala/DurationTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/DurationTest.scala
@@ -1,0 +1,144 @@
+package tools.jackson.module.scala
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tools.jackson.core.`type`.TypeReference
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.scala.util.DurationConverters
+
+import java.time.{Duration => JavaDuration}
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration, DurationInt, DurationLong, FiniteDuration}
+
+object DurationTest {
+  case class DurationWrapper(duration: FiniteDuration)
+}
+
+/**
+ * Ported from https://github.com/pjfanning/jackson-module-scala-duration, whose DurationModule this
+ * module now carries.
+ */
+class DurationTest extends AnyWordSpec with Matchers {
+
+  import DurationTest._
+
+  private val week = DurationWrapper(7.days)
+  private val second = DurationWrapper(1.second)
+
+  private def mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
+
+  private def mapperWith(feature: DateTimeFeature, enabled: Boolean) = {
+    val builder = JsonMapper.builder().addModule(DefaultScalaModule)
+    if (enabled) builder.enable(feature) else builder.disable(feature)
+    builder.build()
+  }
+
+  "DurationModule" should {
+    "write a duration as a period" in {
+      mapper.writeValueAsString(week) shouldEqual """{"duration":"PT168H"}"""
+      mapper.writeValueAsString(second) shouldEqual """{"duration":"PT1S"}"""
+    }
+    "write a duration as a timestamp" in {
+      val timestamps = mapperWith(DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS, enabled = true)
+      timestamps.writeValueAsString(week) shouldEqual """{"duration":604800.000000000}"""
+      timestamps.writeValueAsString(second) shouldEqual """{"duration":1.000000000}"""
+    }
+    "read a duration written as a timestamp" in {
+      mapper.readValue("""{"duration":604800}""", classOf[DurationWrapper]) shouldEqual week
+      mapper.readValue("""{"duration":604800.0000}""", classOf[DurationWrapper]) shouldEqual week
+    }
+    "read a duration written as a period" in {
+      mapper.readValue("""{"duration":"PT168H"}""", classOf[DurationWrapper]) shouldEqual week
+      mapper.readValue("""{"duration":"P7D"}""", classOf[DurationWrapper]) shouldEqual week
+    }
+    "round trip a duration" in {
+      val read = mapper.readValue(mapper.writeValueAsString(week), classOf[DurationWrapper])
+      read shouldEqual week
+    }
+    "write a duration used as a map key" in {
+      mapper.writeValueAsString(Map(second.duration -> "mapped")) shouldEqual """{"PT1S":"mapped"}"""
+    }
+    "read a duration used as a map key" in {
+      val map = mapper.readValue("""{"PT1S":"mapped"}""", new TypeReference[Map[FiniteDuration, String]] {})
+      map should have size 1
+      map(1.second) shouldEqual "mapped"
+    }
+    "be part of a module built by the builder" in {
+      val built = JsonMapper.builder()
+        .addModule(ScalaModule.builder().addAllBuiltinModules().build())
+        .build()
+      built.writeValueAsString(week) shouldEqual """{"duration":"PT168H"}"""
+      built.readValue("""{"duration":"PT168H"}""", classOf[DurationWrapper]) shouldEqual week
+    }
+    "carry a duration finer than a second through JSON" in {
+      val nanos = DurationWrapper(1500000001.nanos)
+      mapper.readValue(mapper.writeValueAsString(nanos), classOf[DurationWrapper]) shouldEqual nanos
+      mapper.writeValueAsString(DurationWrapper(1500.millis)) shouldEqual """{"duration":"PT1.5S"}"""
+    }
+    "be usable on its own, without the rest of the module" in {
+      val alone = JsonMapper.builder().addModule(DurationModule).build()
+      alone.writeValueAsString(7.days) shouldEqual """"PT168H""""
+      alone.readValue(""""PT168H"""", classOf[FiniteDuration]) shouldEqual 7.days
+    }
+  }
+
+  // The 2.13 and Scala 3 builds delegate to scala.jdk.DurationConverters; 2.12 has no such thing in
+  // its standard library - it has no scala.jdk package at all - so that build carries its own copy.
+  // Every case below runs on all three, so the copy is held to exactly what the standard library
+  // answers rather than to what it was written to answer.
+  private val equivalents: Seq[(FiniteDuration, JavaDuration)] = Seq(
+    Duration.Zero -> JavaDuration.ZERO,
+    1.nano -> JavaDuration.ofNanos(1),
+    999999999.nanos -> JavaDuration.ofNanos(999999999),
+    1.micro -> JavaDuration.ofNanos(1000),
+    1.milli -> JavaDuration.ofMillis(1),
+    1.second -> JavaDuration.ofSeconds(1),
+    1.minute -> JavaDuration.ofMinutes(1),
+    1.hour -> JavaDuration.ofHours(1),
+    1.day -> JavaDuration.ofDays(1),
+    7.days -> JavaDuration.ofDays(7),
+    // a whole second carried alongside a fraction of one, which is the case the two halves of the
+    // conversion have to agree about
+    1500000000L.nanos -> JavaDuration.ofSeconds(1, 500000000),
+    2500.millis -> JavaDuration.ofSeconds(2, 500000000),
+    // java.time normalises a negative duration to a negative second count and a positive nano
+    // remainder, so these are not simply the positive cases with a sign
+    (-1).nano -> JavaDuration.ofNanos(-1),
+    (-1500000000L).nanos -> JavaDuration.ofSeconds(-2, 500000000),
+    (-7).days -> JavaDuration.ofDays(-7),
+    // the largest a FiniteDuration goes
+    FiniteDuration(Long.MaxValue, TimeUnit.NANOSECONDS) -> JavaDuration.ofNanos(Long.MaxValue)
+  )
+
+  "DurationConverters" should {
+    "convert a Scala duration to the Java duration it stands for" in {
+      equivalents.foreach { case (scala, java) =>
+        withClue(s"$scala: ") { DurationConverters.toJava(scala) shouldEqual java }
+      }
+    }
+    "convert a Java duration to the Scala duration it stands for" in {
+      equivalents.foreach { case (scala, java) =>
+        withClue(s"$java: ") { DurationConverters.toScala(java) shouldEqual scala }
+      }
+    }
+    "round trip every one of them" in {
+      equivalents.foreach { case (scala, _) =>
+        withClue(s"$scala: ") { DurationConverters.toScala(DurationConverters.toJava(scala)) shouldEqual scala }
+      }
+    }
+    "keep the unit a Scala duration was expressed in out of the answer" in {
+      // FiniteDuration compares by length, so these are equal whatever unit each side chose
+      DurationConverters.toJava(1.second) shouldEqual DurationConverters.toJava(1000.millis)
+      DurationConverters.toScala(JavaDuration.ofDays(7)) shouldEqual 604800.seconds
+    }
+    "refuse a Java duration whose seconds alone overflow a FiniteDuration" in {
+      an[IllegalArgumentException] should be thrownBy
+        DurationConverters.toScala(JavaDuration.ofSeconds(Long.MaxValue, 1))
+    }
+    "refuse a Java duration one nanosecond past the largest FiniteDuration" in {
+      an[IllegalArgumentException] should be thrownBy
+        DurationConverters.toScala(JavaDuration.ofNanos(Long.MaxValue).plusNanos(1))
+    }
+  }
+}


### PR DESCRIPTION
Ports the `DurationModule` from [pjfanning/jackson-module-scala-duration](https://github.com/pjfanning/jackson-module-scala-duration) and adds it to `DefaultScalaModule` and `ScalaModule.Builder.addAllBuiltinModules()`.

The serializers and deserializers are rewritten to this module's conventions — `getInitializers` with an `InitializerBuilder`, a resolver per `Serializers`/`Deserializers` — rather than copied as they stood, and the upstream `JacksonModule` is not brought over since this module has its own.

A `FiniteDuration` is converted to and from a `java.time.Duration`, which databind then reads and writes, so a duration is formatted by whatever the mapper's `DateTimeFeature` settings say — a timestamp, or an ISO-8601 period — exactly as a Java duration would be. Java time support is part of databind in Jackson 3, so nothing new is needed on the classpath.

Values and map keys are both covered, in both directions.

## This changes what an existing mapper writes

`DurationModule` is in `DefaultScalaModule` now, so a `FiniteDuration` that today is written as whatever the fields of the class happen to be in the Scala version in use:

```json
{"duration":{"length":7,"unit":"DAYS","finite":true}}
```

becomes:

```json
{"duration":"PT168H"}
```

The old shape differs between Scala releases and cannot reliably be read back, which is the reason for the change — but it is a wire-format change for anyone serializing durations today, so it wants a release note.

## No new dependency

The conversion is `scala.jdk.DurationConverters` on 2.13 and Scala 3. Scala 2.12 has no `scala.jdk` package at all — I checked the 2.12 `scala-library` jar, it has zero classes under `scala/jdk/` — and there the conversions live in `scala-java8-compat`, which is what the upstream module depends on. Rather than take that dependency for two methods, just those two are copied from `scala.jdk.javaapi.DurationConverters` (Apache 2.0, Copyright EPFL and Lightbend), into `src/main/scala-2.12`, alongside the existing `LazyListSupport` and `TastyUtil` splits.

Copied rather than rewritten — the same overflow check, the same exception, the same answers.

## Tests

`DurationTest` covers the module through a mapper (period and timestamp formats, both read directions, round trips, map keys, sub-second precision, `addAllBuiltinModules`, and the module used on its own), and then the converter directly against a table of Scala/Java equivalents: zero, every `TimeUnit`, nanosecond-only values, seconds carrying a fraction, negatives — which java.time normalises to a negative second count and a *positive* nano remainder, so they are not the positive cases with a sign — the largest `FiniteDuration` there is, and the two ways a Java duration can overflow one.

The same table runs on all three builds, so the 2.12 copy is held to what the standard library answers on 2.13 and 3, not merely to what it was written to answer.

Scala 2.12.21: 655 passed. Scala 2.13.18: 663 passed. Scala 3.3.8: 728 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)