### PR TITLE
tell a fatal error apart from an enum simply having no such case

### DIFF
--- a/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
@@ -12,6 +12,7 @@ import tools.jackson.module.scala.util.Scala3EnumInfo
 import java.lang.reflect.InvocationTargetException
 import scala.reflect.Enum
 import scala.util.Try
+import scala.util.control.NonFatal
 
 private[scala] object EnumDeserializerShared {
   val IntClass = classOf[Int]
@@ -30,42 +31,46 @@ private[scala] object EnumDeserializerShared {
       try {
         method.invoke(None.orNull, 0) != null
       } catch {
-        case _ => false
+        // An enum with no case at ordinal 0 answers by throwing, which is the question being asked
+        // here. Reflection wraps whatever fromOrdinal threw, so the cause is what decides: a fatal
+        // one - an OutOfMemoryError, a thread interrupt - belongs to the caller, not to this
+        // question, and arrives wrapped exactly as an ordinary failure does.
+        case e: InvocationTargetException => e.getCause match {
+          case null => false
+          case NonFatal(_) => false
+          case fatal => throw fatal
+        }
+        case NonFatal(_) => false
       }
     }.getOrElse(false)
   }
 
-  def matchBasedOnOrdinal(clz: Class[_], key: String): Option[_] = {
-    Try(clz.getMethod("fromOrdinal", IntClass)).toOption.flatMap { method =>
-      var i = 0
-      var matched: Option[_] = None
-      var complete = false
-      while (!complete) {
-        try {
-          val enumValue = method.invoke(None.orNull, i)
-          if (enumValue.toString == key) {
-            matched = Some(enumValue)
-            complete = true
-          }
-        } catch {
-          case _: NoSuchElementException => {
-            matched = None
-            complete = true
-          }
-          case itex: InvocationTargetException => {
-            Option(itex.getCause) match {
-              case Some(e) if e.isInstanceOf[NoSuchElementException] => {
-                matched = None
-                complete = true
-              }
-              case Some(e) => throw e
-              case _ => throw itex
-            }
-          }
+  /**
+   * The case of `clz` whose name is `key`, or `None` where it has none.
+   *
+   * Read from the enum's own case table. This used to walk the ordinals instead, calling
+   * `fromOrdinal(0)`, `fromOrdinal(1)` and so on until one of them threw NoSuchElementException -
+   * which cost a reflective call per case on the way to every answer, and ended only if
+   * out-of-range was signalled in that one way, leaving an enum that signalled it differently to be
+   * walked without bound. `values` is generated alongside `fromOrdinal`, by the same enums, and
+   * gives the whole table in a single call that cannot run long or throw at all.
+   */
+  def matchByName(clz: Class[_], key: String): Option[_] = {
+    valuesOf(clz).flatMap(_.find(_.toString == key))
+  }
+
+  private def valuesOf(clz: Class[_]): Option[Array[AnyRef]] = {
+    Try(clz.getMethod("values")).toOption.flatMap { method =>
+      try {
+        Option(method.invoke(None.orNull)).map(_.asInstanceOf[Array[AnyRef]])
+      } catch {
+        case e: InvocationTargetException => e.getCause match {
+          case null => None
+          case NonFatal(_) => None
+          case fatal => throw fatal
         }
-        i += 1
+        case NonFatal(_) => None
       }
-      matched
     }
   }
 
@@ -76,7 +81,7 @@ private case class EnumDeserializer[T <: Enum](clazz: Class[T]) extends StdDeser
     val result = Option(p.getValueAsString).flatMap { text =>
       Try {
         EnumDeserializerShared.tryValueOf(clazz, text)
-          .orElse(EnumDeserializerShared.matchBasedOnOrdinal(clazz, text))
+          .orElse(EnumDeserializerShared.matchByName(clazz, text))
       }.toOption.flatten
     }
     result.getOrElse(throw new IllegalArgumentException(s"Failed to create Enum instance for ${p.getValueAsString}"))
@@ -135,7 +140,7 @@ private case class EnumKeyDeserializer[T <: Enum](clazz: Class[T]) extends KeyDe
   override def deserializeKey(key: String, ctxt: DeserializationContext): AnyRef = {
     val result = Try {
       EnumDeserializerShared.tryValueOf(clazz, key)
-        .orElse(EnumDeserializerShared.matchBasedOnOrdinal(clazz, key))
+        .orElse(EnumDeserializerShared.matchByName(clazz, key))
     }.toOption.flatten
     val enumResult = result.getOrElse(throw new IllegalArgumentException(s"Failed to create Enum instance for $key"))
     enumResult.asInstanceOf[AnyRef]

--- a/src/test/java/tools/jackson/module/scala/deser/OrdinalProbes.java
+++ b/src/test/java/tools/jackson/module/scala/deser/OrdinalProbes.java
@@ -1,0 +1,46 @@
+package tools.jackson.module.scala.deser;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Stand-ins for the shapes EnumDeserializerShared reflects on. Written in Java so that the static
+ * methods it looks for - fromOrdinal, values - can be given behaviour no real Scala 3 enum would
+ * have, which is the behaviour the handling around those calls exists for.
+ */
+public final class OrdinalProbes {
+
+    private OrdinalProbes() {
+    }
+
+    /** fromOrdinal fails the ordinary way: there is no case at that ordinal. */
+    public static final class Absent {
+        public static Object fromOrdinal(int ordinal) {
+            throw new NoSuchElementException(String.valueOf(ordinal));
+        }
+    }
+
+    /** fromOrdinal fails with an error that belongs to the caller rather than to the question. */
+    public static final class Fatal {
+        public static Object fromOrdinal(int ordinal) {
+            throw new OutOfMemoryError("thrown by the enum, not by the JVM");
+        }
+    }
+
+    /** fromOrdinal fails by interrupting, which is also the caller's business. */
+    public static final class Interrupting {
+        public static Object fromOrdinal(int ordinal) throws InterruptedException {
+            throw new InterruptedException("thrown by the enum");
+        }
+    }
+
+    /** fromOrdinal answers for every ordinal there is, so walking them never reaches an end. */
+    public static final class Unbounded {
+        public static Object fromOrdinal(int ordinal) {
+            return "case" + ordinal;
+        }
+
+        public static Object[] values() {
+            return new Object[] { "case0", "case1" };
+        }
+    }
+}

--- a/src/test/scala-3/tools/jackson/module/scala/deser/EnumDeserializerSharedSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/deser/EnumDeserializerSharedSpec.scala
@@ -1,0 +1,58 @@
+package tools.jackson.module.scala.deser
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+enum SharedProbeEnum {
+  case Red, Green, Blue
+}
+
+class EnumDeserializerSharedSpec extends AnyWordSpec with Matchers {
+
+  "canFindByOrdinal" should {
+    "answer true for an enum that has a case at ordinal 0" in {
+      EnumDeserializerShared.canFindByOrdinal(classOf[SharedProbeEnum]) shouldBe true
+    }
+    "answer false for a class with no fromOrdinal at all" in {
+      EnumDeserializerShared.canFindByOrdinal(classOf[String]) shouldBe false
+    }
+    "answer false when fromOrdinal fails the ordinary way" in {
+      EnumDeserializerShared.canFindByOrdinal(classOf[OrdinalProbes.Absent]) shouldBe false
+    }
+    // reflection wraps whatever the method threw, so both of these reach the catch as an
+    // InvocationTargetException and are told apart only by their cause
+    "let a fatal error through rather than answering false" in {
+      an[OutOfMemoryError] should be thrownBy
+        EnumDeserializerShared.canFindByOrdinal(classOf[OrdinalProbes.Fatal])
+    }
+    "let an interrupt through rather than answering false" in {
+      an[InterruptedException] should be thrownBy
+        EnumDeserializerShared.canFindByOrdinal(classOf[OrdinalProbes.Interrupting])
+    }
+  }
+
+  "matchByName" should {
+    "find the case that goes by the name" in {
+      EnumDeserializerShared.matchByName(classOf[SharedProbeEnum], "Green") shouldEqual Some(SharedProbeEnum.Green)
+    }
+    "find nothing for a name no case goes by" in {
+      EnumDeserializerShared.matchByName(classOf[SharedProbeEnum], "Purple") shouldBe empty
+    }
+    "find nothing for a class with no case table" in {
+      EnumDeserializerShared.matchByName(classOf[String], "Green") shouldBe empty
+    }
+    "answer without walking the ordinals" in {
+      // this one answers fromOrdinal for every ordinal there is, so the walk it replaced would not
+      // have ended. The read runs on its own thread so a regression reports rather than hangs.
+      @volatile var result: Option[_] = null
+      val reader = new Thread(() => result = EnumDeserializerShared.matchByName(classOf[OrdinalProbes.Unbounded], "case1"))
+      reader.setDaemon(true)
+      reader.start()
+      reader.join(30000)
+      withClue("matching a name against an endless case table did not terminate: ") {
+        reader.isAlive shouldBe false
+      }
+      result shouldEqual Some("case1")
+    }
+  }
+}


### PR DESCRIPTION
Two fixes in `EnumDeserializerShared`, both about what happens around the reflective calls it makes on a Scala 3 enum.

## `canFindByOrdinal` swallowed everything

```scala
catch { case _ => false }
```

A bare `case _` matches `Throwable`, so an `OutOfMemoryError` or a thread interrupt raised while answering a question *about* an enum was swallowed and reported as "this enum has no ordinals".

`NonFatal` alone would not have fixed it. Reflection wraps whatever the invoked method threw, so a fatal error arrives as an `InvocationTargetException` exactly as an ordinary failure does — and `NonFatal` says the wrapper is non-fatal whatever is inside it. The cause is what decides, which is also how `matchBasedOnOrdinal` already handled the same call.

## `matchBasedOnOrdinal` walked the ordinals

It found a case by name by calling `fromOrdinal(0)`, `fromOrdinal(1)`, and so on until one of them threw `NoSuchElementException`. Two problems:

- **a reflective call per case, on the way to every answer** — plus a thrown-and-caught exception to finish, paid on every name that `valueOf` did not resolve;
- **it ended only if out-of-range was signalled that one way.** An enum that signalled it by *answering* instead would be walked without bound.

`values` is generated alongside `fromOrdinal`, by the same enums — `javap` on a compiled `enum Color { case Red, Green, Blue }` shows `static Color[] values()`, `static Color valueOf(String)` and `static Color fromOrdinal(int)` together — and it hands over the whole case table in a single call that cannot run long or throw at all. So the walk is gone, and the method is renamed `matchByName` for what it now does.

## Tests

`EnumDeserializerSharedSpec`, with Java fixtures in `src/test/java` so the static methods being reflected on can behave in ways no real Scala 3 enum would:

- `fromOrdinal` throwing `NoSuchElementException` still answers `false`;
- `fromOrdinal` throwing `OutOfMemoryError`, and one throwing `InterruptedException`, now reach the caller instead of becoming `false`;
- `matchByName` finds a case by name, finds nothing for an unknown name or a class with no case table;
- a fixture whose `fromOrdinal` answers for *every* ordinal — the shape the old walk never finished on — is matched against on its own daemon thread with a join timeout, so a regression reports a failure rather than hanging the suite.

Scala 3.3.8: 744 passed, 0 failed. Scala 2.13.18: 665 passed. Scala 2.12.21: 657 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)