### PR TITLE
report a bad enumClass as a databind problem, and find it the mapper's way

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/deser/EnumerationDeserializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/EnumerationDeserializerModule.scala
@@ -9,6 +9,8 @@ import tools.jackson.module.scala.JacksonModule.InitializerBuilder
 import tools.jackson.module.scala.util.EnumResolver
 import tools.jackson.module.scala.{JacksonModule => JacksonScalaModule}
 
+import scala.util.control.NonFatal
+
 private trait ContextualEnumerationDeserializer {
   self: ValueDeserializer[Enumeration#Value] =>
 
@@ -35,10 +37,38 @@ private class EnumerationDeserializer(theType: JavaType) extends ValueDeserializ
           ctxt.handleUnexpectedToken(theType, jp).asInstanceOf[Enumeration#Value]
         } else {
           jp.nextToken()
-          Class.forName(eclassName + "$", false, getClass.getClassLoader)
-            .getField("MODULE$").get(None.orNull).asInstanceOf[Enumeration].withName(valueValue)
+          enumerationValue(eclassName, valueValue, ctxt)
         }
       }
+    }
+  }
+
+  /**
+   * The value `valueName` of the Enumeration named by `enumClassName`.
+   *
+   * The JSON names the class, so both halves of this fail on input a service does not control: the
+   * class may not be there, and the name may not be one of its values. Either is a databind problem
+   * and is reported as one, rather than letting a raw ClassNotFoundException or NoSuchElementException
+   * out of readValue past everything catching JacksonException.
+   */
+  private def enumerationValue(enumClassName: String, valueName: String, ctxt: DeserializationContext): Enumeration#Value = {
+    val enumeration =
+      try {
+        // the mapper's loader first: this module's own is the wrong one wherever the application's
+        // classes are loaded by a child loader, which is where this used to fail to find them
+        val loader = Option(ctxt.getTypeFactory.getClassLoader).getOrElse(getClass.getClassLoader)
+        Class.forName(enumClassName + "$", false, loader)
+          .getField("MODULE$").get(None.orNull).asInstanceOf[Enumeration]
+      } catch {
+        case NonFatal(e) =>
+          return ctxt.handleInstantiationProblem(classOf[Enumeration], enumClassName, e)
+            .asInstanceOf[Enumeration#Value]
+      }
+    try enumeration.withName(valueName)
+    catch {
+      case NonFatal(_) =>
+        ctxt.handleWeirdStringValue(enumeration.getClass, valueName,
+          s"not a value of Enumeration $enumClassName").asInstanceOf[Enumeration#Value]
     }
   }
 

--- a/src/test/scala/tools/jackson/module/scala/deser/EnumerationDeserializerTest.scala
+++ b/src/test/scala/tools/jackson/module/scala/deser/EnumerationDeserializerTest.scala
@@ -7,7 +7,12 @@ import tools.jackson.module.scala.OuterWeekday.InnerWeekday
 import tools.jackson.module.scala.Weekday
 import tools.jackson.module.scala.ser.EnumerationSerializerTest.{AnnotationHolder, AnnotationOptionHolder, WeekdayType}
 
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.`type`.TypeFactory
+import tools.jackson.databind.json.JsonMapper
+
 import scala.beans.BeanProperty
+import scala.collection.mutable
 
 class EnumContainer {
   var day: Weekday.Value = Weekday.Fri
@@ -67,6 +72,36 @@ class EnumerationDeserializerTest extends DeserializerTest {
   it should "deserialize an annotated optional Enumeration value (JsonScalaEnumeration)" in {
     val result = deserialize(annotatedFridayJson, classOf[AnnotationOptionHolder])
     result.weekday shouldBe Some(Weekday.Fri)
+  }
+
+  // read at the root rather than as a bean property: a property deserializer wraps what it catches,
+  // so the root is where a raw reflection failure escapes readValue
+  it should "report an enumClass it cannot find as a databind problem" in {
+    val json = """{"enumClass":"tools.jackson.module.scala.NoSuchWeekday","value":"Fri"}"""
+    val thrown = the[DatabindException] thrownBy newMapper.readValue(json, classOf[Weekday.Value])
+    thrown.getMessage should include("NoSuchWeekday")
+  }
+
+  it should "report a value the Enumeration does not have as a databind problem" in {
+    val json = """{"enumClass":"tools.jackson.module.scala.Weekday","value":"Caturday"}"""
+    val thrown = the[DatabindException] thrownBy newMapper.readValue(json, classOf[Weekday.Value])
+    thrown.getMessage should include("Caturday")
+  }
+
+  it should "resolve the enumClass through the mapper's own classloader" in {
+    val asked = mutable.Buffer[String]()
+    val recording = new ClassLoader(getClass.getClassLoader) {
+      override def loadClass(name: String, resolve: Boolean): Class[_] = {
+        asked += name
+        super.loadClass(name, resolve)
+      }
+    }
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .typeFactory(TypeFactory.createDefaultInstance().withClassLoader(recording))
+      .build()
+    mapper.readValue(fridayEnumJson, classOf[EnumContainer]).day should be (Weekday.Fri)
+    asked should contain ("tools.jackson.module.scala.Weekday$")
   }
 
   val fridayEnumJson = """{"day": {"enumClass":"tools.jackson.module.scala.Weekday","value":"Fri"}}"""


### PR DESCRIPTION
The legacy `{"enumClass":...,"value":...}` form names the class in the JSON, so both halves of resolving it can fail on input a service does not control — and both failed by throwing straight out of `readValue`:

```
java.lang.ClassNotFoundException: tools.jackson.module.scala.NoSuchWeekday$
java.util.NoSuchElementException: Caturday
```

Neither is a `JacksonException`, so neither is caught by anything catching one. They go through `handleInstantiationProblem` and `handleWeirdStringValue` now, which is what the rest of the module does with input it cannot make sense of.

Worth noting for review: a bean property already wrapped these on the way past, so it is a **root-level** read that lets them out — which is why the tests read at the root rather than into `EnumContainer` like the cases around them.

## Classloader

```scala
Class.forName(eclassName + "$", false, getClass.getClassLoader)
```

That is this module's own loader. It is the wrong one wherever the application's classes are loaded by a child loader — a container, OSGi, a script engine — which is exactly the setting where an `enumClass` that genuinely does exist would not be found. The mapper's own loader (`ctxt.getTypeFactory.getClassLoader`) is asked first now, with the module's kept as the fallback for when none is configured, so the default path is unchanged.

## Tests

Three cases in `EnumerationDeserializerTest`, all verified failing without the main-source change:

- an unknown `enumClass` → `DatabindException` (was `ClassNotFoundException`);
- a value the Enumeration does not have → `DatabindException` (was `NoSuchElementException`);
- a mapper given a `TypeFactory` with a recording classloader → that loader is asked for `Weekday$` (was: never consulted, `ArrayBuffer()` empty).

Scala 2.12.21: 660 passed. Scala 2.13.18: 668 passed. Scala 3.3.8: 738 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)