### PR TITLE
look for a .tasty file with the loader that has it

### DIFF
--- a/src/main/scala-2.13/tools/jackson/module/scala/util/TastyUtil.scala
+++ b/src/main/scala-2.13/tools/jackson/module/scala/util/TastyUtil.scala
@@ -3,8 +3,7 @@ package tools.jackson.module.scala.util
 import scala.annotation.tailrec
 
 private[util] object TastyUtil {
-  private val thisClass = TastyUtil.getClass
-  
+
   @tailrec
   def hasTastyFile(clz: Class[_]): Boolean = {
     if (clz == null) {
@@ -19,7 +18,11 @@ private[util] object TastyUtil {
           baseName
         }
         val tastyFile = s"/$classFileBase.tasty"
-        Option(thisClass.getResource(tastyFile)).isDefined
+        // asked of the class being checked, not of this one: the two share a classloader only when
+        // the application's classes were loaded by the same one as the module's. Where they were
+        // not - a container, OSGi, a script engine - this module's loader cannot see the .tasty of
+        // a class it did not load, and every such class would be taken for a Java class.
+        Option(clz.getResource(tastyFile)).isDefined
       } || hasTastyFile(clz.getEnclosingClass)
     }
   }

--- a/src/test/java/tools/jackson/module/scala/util/TastyProbe.java
+++ b/src/test/java/tools/jackson/module/scala/util/TastyProbe.java
@@ -1,0 +1,9 @@
+package tools.jackson.module.scala.util;
+
+/**
+ * A Java class, so no .tasty file of its own is ever on the classpath. What answers for one in
+ * TastyUtilTest is a classloader that made it up - which only works if the class's own loader is
+ * the one being asked.
+ */
+public final class TastyProbe {
+}

--- a/src/test/scala-3/tools/jackson/module/scala/util/TastyUtilTest.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/util/TastyUtilTest.scala
@@ -2,6 +2,39 @@ package tools.jackson.module.scala.util
 
 import tools.jackson.module.scala.{BaseSpec, Weekday}
 
+import java.io.ByteArrayOutputStream
+import java.net.{URI, URL}
+
+/**
+ * Loads a class itself rather than delegating, and answers for the .tasty file of anything it
+ * loaded - which stands in for the container, OSGi or script engine loader that holds an
+ * application's classes while this module is held by another.
+ */
+private class TastyChildLoader(parent: ClassLoader) extends ClassLoader(parent) {
+
+  var asked: List[String] = Nil
+
+  def define(name: String): Class[_] = {
+    val stream = parent.getResourceAsStream(name.replace('.', '/') + ".class")
+    val bytes = new ByteArrayOutputStream()
+    try {
+      val chunk = new Array[Byte](8192)
+      var read = stream.read(chunk)
+      while (read >= 0) {
+        bytes.write(chunk, 0, read)
+        read = stream.read(chunk)
+      }
+    } finally stream.close()
+    val defined = bytes.toByteArray
+    defineClass(name, defined, 0, defined.length)
+  }
+
+  override def getResource(name: String): URL = {
+    asked = name :: asked
+    if (name.endsWith(".tasty")) URI.create(s"file:///$name").toURL else super.getResource(name)
+  }
+}
+
 class TastyUtilTest extends BaseSpec {
 
   "TastyUtil.hasTastyFile" should "support EnumResolver (class)" in {
@@ -27,5 +60,14 @@ class TastyUtilTest extends BaseSpec {
   }
   it should "not support Java class" in {
     TastyUtil.hasTastyFile(classOf[String]) shouldBe false
+  }
+  // TastyProbe is a Java class, so the classpath holds no .tasty for it. The only one that exists is
+  // the one its loader makes up, and that loader is reached only by asking the class itself.
+  it should "ask the classloader of the class it was handed" in {
+    val loader = new TastyChildLoader(getClass.getClassLoader)
+    val loaded = loader.define(classOf[TastyProbe].getName)
+    loaded.getClassLoader shouldBe loader
+    TastyUtil.hasTastyFile(loaded) shouldBe true
+    loader.asked should contain ("tools/jackson/module/scala/util/TastyProbe.tasty")
   }
 }


### PR DESCRIPTION
`hasTastyFile` asked its own class for the resource:

```scala
Option(thisClass.getResource(tastyFile)).isDefined
```

`Class.getResource` goes to the class's *defining* classloader, so that is this module's loader — which can see the `.tasty` of an application's classes only when it happens to have loaded them. Where it did not (a container, OSGi, a script engine, anything child-first), no Scala 3 class has a `.tasty` as far as this can tell, and `extendsScalaClass` quietly takes every one of them for a Java class.

The class being asked about is the one that knows where its own `.tasty` is, so it is the one asked now.

Only the `scala-2.13` source has this (it is compiled for both 2.13 and Scala 3). The 2.12 build's `TastyUtil` answers `false` without looking at anything, so there is nothing to change there.

## Tests

A case added to the existing `TastyUtilTest`, with `TastyChildLoader` standing in for the loader that holds an application's classes while this module is held by another: it defines a class itself rather than delegating, and answers for the `.tasty` of anything it loaded.

The class it loads is `TastyProbe`, a **Java** class — deliberately, because the classpath then holds no `.tasty` for it at all. The only one that exists is the one the child loader makes up, so the test can only pass if that loader is the one being asked. Verified failing without the change (`false was not equal to true`).

Scala 3.3.8: 745 passed. Scala 2.13.18: 665 passed. Scala 2.12.21: 657 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)