### PR TITLE
refuse a second @type instead of reading past it

### DIFF
--- a/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
+++ b/src/main/scala-3/tools/jackson/module/scala/deser/EnumDeserializerModule.scala
@@ -117,7 +117,13 @@ private case class Scala3EnumSumDeserializer[T <: Enum](info: Scala3EnumInfo.Inf
     while (p.nextToken() != JsonToken.END_OBJECT) {
       val name = p.currentName()
       p.nextToken()
-      if (typeId == null && name == Scala3EnumInfo.TypePropertyName) {
+      if (name == Scala3EnumInfo.TypePropertyName) {
+        // a second one is refused rather than written on as an ordinary property: which of the two
+        // the case was read from would otherwise depend on nothing but their order
+        if (typeId != null) {
+          ctxt.reportInputMismatch(info.rootClass,
+            s"Duplicate ${Scala3EnumInfo.TypePropertyName} property: '$typeId' then '${p.getValueAsString}'")
+        }
         typeId = p.getValueAsString
       } else {
         buffer.writeName(name)
@@ -128,7 +134,9 @@ private case class Scala3EnumSumDeserializer[T <: Enum](info: Scala3EnumInfo.Inf
     val enumCase = Option(typeId).flatMap(info.caseForName).getOrElse(failed(typeId))
     enumCase.singleton match {
       case Some(singleton) => singleton
-      case None => ctxt.readValue(buffer.asParserOnFirstToken(ctxt), enumCase.clazz.asInstanceOf[Class[AnyRef]])
+      // the source parser is handed over so that what is read from the buffer still reports where in
+      // the input it came from - databind's own AsPropertyTypeDeserializer buffers the same way
+      case None => ctxt.readValue(buffer.asParserOnFirstToken(ctxt, p), enumCase.clazz.asInstanceOf[Class[AnyRef]])
     }
   }
 

--- a/src/main/scala/tools/jackson/module/scala/deser/SealedPolymorphismDeserializerModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/deser/SealedPolymorphismDeserializerModule.scala
@@ -18,7 +18,13 @@ private object TaggedObject {
     while (p.nextToken() != JsonToken.END_OBJECT) {
       val name = p.currentName()
       p.nextToken()
-      if (typeName == null && name == SealedPolymorphism.TypePropertyName) {
+      if (name == SealedPolymorphism.TypePropertyName) {
+        // a second one is refused rather than written on as an ordinary property: which of the two
+        // the value was read as would otherwise depend on nothing but their order
+        if (typeName != null) {
+          ctxt.reportInputMismatch(classOf[AnyRef],
+            s"Duplicate ${SealedPolymorphism.TypePropertyName} property: '$typeName' then '${p.getValueAsString}'")
+        }
         typeName = p.getValueAsString
       } else {
         buffer.writeName(name)
@@ -26,7 +32,9 @@ private object TaggedObject {
       }
     }
     buffer.writeEndObject()
-    (typeName, buffer.asParserOnFirstToken(ctxt))
+    // the source parser is handed over so that what is read from the buffer still reports where in
+    // the input it came from - databind's own AsPropertyTypeDeserializer buffers the same way
+    (typeName, buffer.asParserOnFirstToken(ctxt, p))
   }
 
   def failed(baseClass: Class[_], typeName: String): Nothing =

--- a/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtDeserializerSpec.scala
+++ b/src/test/scala-3/tools/jackson/module/scala/enum/adt/AdtDeserializerSpec.scala
@@ -1,5 +1,6 @@
 package tools.jackson.module.scala.`enum`.adt
 
+import tools.jackson.databind.DatabindException
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.scala.DefaultScalaModule
 import org.scalatest.matchers.should.Matchers
@@ -22,6 +23,11 @@ class AdtDeserializerSpec extends AnyWordSpec with Matchers {
     "deserialize Color.Mix" in {
       val json = mapper.writeValueAsString(Color.Mix(0x4488FF))
       mapper.readValue(json, classOf[Color]) shouldEqual Color.Mix(0x4488FF)
+    }
+    "refuse a second @type rather than reading past it" in {
+      val json = """{"@type":"Mix","@type":"Red","mix":4491519}"""
+      val thrown = the[DatabindException] thrownBy mapper.readValue(json, classOf[Color])
+      thrown.getMessage should include("Duplicate @type")
     }
     "deserialize ColorSet" in {
       val colors = ColorSet(Set(Color.Red, Color.Green, Color.Mix(0x4488FF)))

--- a/src/test/scala/tools/jackson/module/scala/poly/SealedPolymorphismSpec.scala
+++ b/src/test/scala/tools/jackson/module/scala/poly/SealedPolymorphismSpec.scala
@@ -1,6 +1,7 @@
 package tools.jackson.module.scala.poly
 
 import tools.jackson.core.`type`.TypeReference
+import tools.jackson.databind.DatabindException
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.scala.{DefaultScalaModule, ScalaModule, SealedPolymorphismModule}
 import tools.jackson.module.scala.deser.SealedPolymorphismDeserializerModule
@@ -26,6 +27,15 @@ class SealedPolymorphismSpec extends AnyWordSpec with Matchers {
     "round trip an implementation declared beside the base type" in {
       roundTrip(Owner("ann", Dog("rex")), classOf[Owner]) shouldEqual Owner("ann", Dog("rex"))
       roundTrip(Owner("ann", Bird("tweety", true)), classOf[Owner]) shouldEqual Owner("ann", Bird("tweety", true))
+    }
+    "refuse a second @type rather than reading past it" in {
+      // the old handling kept the first and let the second through as an ordinary property, which
+      // addIgnorable then dropped - so which of the two was used came down to their order
+      val json = """{"name":"ann","pet":{"@type":"Dog","@type":"Bird","name":"rex"}}"""
+      val thrown = the[DatabindException] thrownBy mapper.readValue(json, classOf[Owner])
+      thrown.getMessage should include("Duplicate @type")
+      thrown.getMessage should include("Dog")
+      thrown.getMessage should include("Bird")
     }
     "round trip a case object to the same instance" in {
       roundTrip(Owner("ann", Unknown), classOf[Owner]).pet should be theSameInstanceAs Unknown


### PR DESCRIPTION
## The duplicate `@type` (a real fix)

Both places that split a tagged object — `TaggedObject.split` for sealed hierarchies and `Scala3EnumSumDeserializer.fromObject` for enum sums — kept the first `@type` and let any later one through as an ordinary property:

```scala
if (typeName == null && name == SealedPolymorphism.TypePropertyName) {
```

The sealed path then had `addIgnorable("@type")` quietly drop it, and the enum path handed it to the case class. So a document carrying two of them was read without complaint, and which one decided the type came down to nothing but their order. Both report it now, through `reportInputMismatch`:

```
MismatchedInputException: Duplicate @type property: 'Dog' then 'Bird'
```

## The buffered parser (alignment, not a fix — I was wrong about this one)

I raised this as an error-location problem. It isn't, and I should correct that: **I could find no behaviour that `asParserOnFirstToken(ctxt, p)` changes here.**

`ctxt.bufferForInputBuffering(p)` has already been handed the same parser and takes the stream read constraints from it, so the two-arg form's first job is a no-op. Its second is to set the location from `src.currentTokenLocation()` — and an error raised while reading the buffer reports identically either way. Reading a tagged object whose payload fails to convert gives the same line, column, character offset and source reference with the change and without it, with `INCLUDE_SOURCE_IN_LOCATION` both enabled and disabled:

```
PROBE-LOC line=2 col=55 char=69 src=true   // with
PROBE-LOC line=2 col=55 char=69 src=true   // without
```

I have kept the change because it is what the call is for — passing the source explicitly rather than relying on the buffer having been handed it earlier, which is how databind's own `AsPropertyTypeDeserializer` does it — but it is housekeeping, and worth dropping if you would rather not carry the churn.

## Tests

A case in `SealedPolymorphismSpec` and one in `AdtDeserializerSpec`, both verified failing without the main-source change — "Expected exception DatabindException to be thrown, but no exception was thrown", which is the silent acceptance the fix is about.

Scala 3.3.8: 746 passed. Scala 2.13.18: 666 passed. Scala 2.12.21: 658 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)