### PR TITLE
consume a case object's JSON without eating the tokens around it

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/deser/ScalaObjectDeserializerModule.scala
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.module.scala.deser
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind._
@@ -12,11 +12,12 @@ import scala.util.control.NonFatal
 
 private class ScalaObjectDeserializer(value: Any) extends StdDeserializer[Any](classOf[Any]) {
   override def deserialize(p: JsonParser, ctxt: DeserializationContext): Any = {
-    if (p.currentToken() != JsonToken.END_OBJECT) {
-      while (p.nextToken() != JsonToken.END_OBJECT) {
-        // consume the object
-      }
-    }
+    // A Scala object holds no state, so whatever was written for it is consumed and discarded.
+    // skipChildren stops at the end token matching the one it started on - not at the first one it
+    // meets - and does nothing at all for a scalar, so a nested object no longer ends the value
+    // early and a scalar no longer eats the tokens of whatever encloses it. Reading a scalar at the
+    // root used to spin forever here: nextToken returns null at end of input, never END_OBJECT.
+    p.skipChildren()
     value
   }
 }

--- a/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/deser/CaseObjectDeserializerTest.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonAutoDetect, PropertyAccessor}
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
-import com.fasterxml.jackson.module.scala.deser.CaseObjectDeserializerTest.{Foo, TestObject}
+import com.fasterxml.jackson.module.scala.deser.CaseObjectDeserializerTest.{Foo, Holder, TestObject}
 import com.fasterxml.jackson.module.scala.introspect.ScalaAnnotationIntrospectorModule
 
 object CaseObjectDeserializerTest {
@@ -13,6 +13,8 @@ object CaseObjectDeserializerTest {
   case object Foo {
     val field: String = "bar"
   }
+
+  case class Holder(obj: TestObject.type, after: Int)
 }
 
 class CaseObjectDeserializerTest extends DeserializerTest {
@@ -65,6 +67,38 @@ class CaseObjectDeserializerTest extends DeserializerTest {
     val json = mapper.writeValueAsString(original)
     val deserialized = mapper.readValue[TestObject.type](json)
     assert(deserialized === original)
+  }
+
+  it should "leave the tokens of the enclosing object alone" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":{},"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "skip a nested object written where a case object is expected" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":{"x":{"y":1}},"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "skip a scalar written where a case object is expected" in {
+    val mapper = newMapper
+    mapper.readValue("""{"obj":5,"after":7}""", classOf[Holder]) shouldEqual Holder(TestObject, 7)
+  }
+
+  it should "not hang on a scalar read as a case object" in {
+    // the read runs on its own thread: a regression here spins forever rather than failing, and the
+    // suite has to be able to report that instead of hanging with it
+    val mapper = newMapper
+    @volatile var result: Any = null
+    val reader = new Thread(new Runnable {
+      override def run(): Unit = result = mapper.readValue("5", TestObject.getClass)
+    })
+    reader.setDaemon(true)
+    reader.start()
+    reader.join(30000)
+    withClue("reading a scalar as a case object did not terminate: ") {
+      reader.isAlive shouldBe false
+    }
+    result shouldEqual TestObject
   }
 
   "An ObjectMapper without ScalaObjectDeserializerModule" should "deserialize a case object but create a new instance" in {


### PR DESCRIPTION
Backport of #843 (3.x) / the same change on 3.1, converted to the Jackson 2 packages.

`ScalaObjectDeserializer` discarded the value written for a Scala `object` by looping until it saw an `END_OBJECT`, whichever one that turned out to be:

```scala
while (p.nextToken() != JsonToken.END_OBJECT) {}
```

Three ways that reads the wrong tokens:

| input | before | after |
|---|---|---|
| `{"obj":{"x":{"y":1}},"after":7}` | trailing-token error — the value ends at the *nested* `END_OBJECT` | `Holder(TestObject, 7)` |
| `{"obj":5,"after":7}` | `Holder(TestObject, 0)` — the enclosing `END_OBJECT` is consumed and `after` is silently lost | `Holder(TestObject, 7)` |
| `readValue("5", TestObject.getClass)` | **spins forever** — at the root `nextToken()` returns `null` at end of input, never `END_OBJECT` | `TestObject` |

The last one hangs a thread on input a service does not control, so it is reachable from untrusted JSON.

`skipChildren()` stops at the end token matching the one it started on rather than at the first one it meets, and does nothing at all for a scalar — which is what this code wanted in all three cases.

The 2.x source is identical to 3.x here apart from the package, so this is the same one-line change plus the now-unused `JsonToken` import dropped.

## Tests

Four cases added to `CaseObjectDeserializerTest`. The non-termination one runs the read on its own daemon thread and joins with a timeout, so a regression reports a failure instead of hanging the suite; the `Runnable` is spelled out rather than using a SAM lambda, since 2.x still cross-builds Scala 2.11.

Full suite on 2.13.18: 663 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)