### PR TITLE
report an Iterator as empty when it is empty, not when it is not

### DIFF
--- a/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
+++ b/src/main/scala/com/fasterxml/jackson/module/scala/ser/IteratorSerializerModule.scala
@@ -28,7 +28,8 @@ private trait IteratorSerializer
     new ResolvedIteratorSerializer(this, property, vts, elementSerializer, unwrapSingle)
 
 
-  override def isEmpty(serializerProvider: SerializerProvider, value: collection.Iterator[Any]): Boolean = value.hasNext
+  // hasNext leaves the iterator where it found it, so this is safe to ask before serializing
+  override def isEmpty(serializerProvider: SerializerProvider, value: collection.Iterator[Any]): Boolean = !value.hasNext
 }
 
 private class ResolvedIteratorSerializer( src: IteratorSerializer,

--- a/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
+++ b/src/test/scala/com/fasterxml/jackson/module/scala/ser/IterableSerializerTest.scala
@@ -7,6 +7,16 @@ import org.scalatest.matchers.Matcher
 
 import scala.collection.{Iterator, immutable, mutable}
 
+class NonEmptyIterators {
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  def emptyIterator: Iterator[Int] = Iterator.empty
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  def nonEmptyIterator: Iterator[Int] = Iterator(1, 2, 3)
+}
+
 class NonEmptyCollections {
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -114,6 +124,10 @@ class IterableSerializerTest extends SerializerTest {
 
   it should "honor the JsonInclude(NON_EMPTY) annotation" in {
     serialize(new NonEmptyCollections) should be("""{"nonEmptyIterable":[1,2,3]}""")
+  }
+
+  it should "honor the JsonInclude(NON_EMPTY) annotation for Iterators" in {
+    serialize(new NonEmptyIterators) should be("""{"nonEmptyIterator":[1,2,3]}""")
   }
 
   it should "honor JsonTypeInfo" in {


### PR DESCRIPTION
Backport of #844 (3.x) / the same change on 3.1, converted to the Jackson 2 packages.

`IteratorSerializer.isEmpty` returned `value.hasNext`, missing the negation:

```scala
override def isEmpty(provider: SerializerProvider, value: Iterator[Any]): Boolean = value.hasNext
```

`IterableSerializer` (`value.isEmpty`) and `ScalaIteratorSerializer` (`value.isEmpty`) beside it both answer this correctly — this one is the odd one out.

Under `@JsonInclude(NON_EMPTY)` the effect is exactly backwards: the empty `Iterator` is written and the one with elements in it is dropped.

```
{"emptyIterator":[]}            // before
{"nonEmptyIterator":[1,2,3]}    // after
```

`hasNext` leaves the iterator where it found it, so asking before serializing stays safe — no element is consumed by the check.

## Tests

`NonEmptyIterators` and a matching case in `IterableSerializerTest`, alongside the `NonEmptyCollections` one that has always covered the `Iterable` side. `Iterator.empty` is left unparameterised so it compiles on 2.11 as well.

Full suite on 2.13.18: 660 passed, 0 failed. MiMa clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)