### PR TITLE
hold the registered referenced types in a map that can take concurrent writes

### DIFF
--- a/src/main/scala/tools/jackson/module/scala/introspect/ClassHolder.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/ClassHolder.scala
@@ -1,6 +1,11 @@
 package tools.jackson.module.scala.introspect
 
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{Map => MutableMap}
 
 private[introspect] case class ClassHolder(valueClass: Option[Class[_]] = None)
-private[introspect] case class ClassOverrides(overrides: MutableMap[String, ClassHolder] = MutableMap.empty)
+
+// The map is concurrent because a registration is no longer only something an application makes at
+// startup: introspecting a class registers what it derived, on whatever thread got there first.
+// Declared as the general type so that what this holds stays an implementation detail.
+private[introspect] case class ClassOverrides(overrides: MutableMap[String, ClassHolder] = TrieMap.empty)

--- a/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
+++ b/src/main/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorModule.scala
@@ -15,6 +15,7 @@ import tools.jackson.module.scala.{DefaultLookupCacheFactory, JacksonModule, Loo
 import tools.jackson.module.scala.util.Implicits._
 
 import java.lang.annotation.Annotation
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{Map => MutableMap}
 
 class ScalaAnnotationIntrospectorInstance(scalaAnnotationIntrospectorModule: ScalaAnnotationIntrospectorModule,
@@ -283,18 +284,26 @@ trait ScalaAnnotationIntrospectorModule extends JacksonModule {
   private var _descriptorCacheSize: Int = 100
   private var _scalaTypeCacheSize: Int = 1000
 
-  private[introspect] val overrideMap = MutableMap[String, ClassOverrides]()
+  // Registering a referenced value type used to be something an application did at startup, from one
+  // thread, before any mapper was used. It is not any more: introspecting a class registers what it
+  // captured by deriving ScalaTypeInfo, and that happens on whatever application thread first
+  // deserializes the class - and again for every class whose bean descriptor has been evicted. A
+  // plain mutable.HashMap read and written that way can lose an entry, or leave a reader walking a
+  // bucket chain that a resize is in the middle of moving.
+  // Declared as the general type it has always had, so this stays an implementation detail rather
+  // than a signature change; TrieMap.getOrElseUpdate is atomic on every version cross-built here.
+  private[introspect] val overrideMap: MutableMap[String, ClassOverrides] = TrieMap.empty
 
-  private[introspect] var _descriptorCache: LookupCache[String, BeanDescriptor] =
+  @volatile private[introspect] var _descriptorCache: LookupCache[String, BeanDescriptor] =
     _lookupCacheFactory.createLookupCache(16, _descriptorCacheSize)
 
-  private[introspect] var _scalaTypeCache: LookupCache[String, Boolean] =
+  @volatile private[introspect] var _scalaTypeCache: LookupCache[String, Boolean] =
     _lookupCacheFactory.createLookupCache(16, _scalaTypeCacheSize)
 
   // What each class captured by deriving ScalaTypeInfo. Belongs to this module instance like the
   // caches above it, so a module built through ScalaModule.Builder remembers what it has read
   // independently of every other module.
-  private[introspect] var _derivedTypeInfo: DerivedTypeInfo = new DerivedTypeInfo(_lookupCacheFactory)
+  @volatile private[introspect] var _derivedTypeInfo: DerivedTypeInfo = new DerivedTypeInfo(_lookupCacheFactory)
 
   /**
    * jackson-module-scala does not always properly handle deserialization of Options or Collections wrapping

--- a/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
+++ b/src/test/scala/tools/jackson/module/scala/introspect/ScalaAnnotationIntrospectorStateSpec.scala
@@ -5,6 +5,8 @@ import tools.jackson.module.scala.{DefaultLookupCacheFactory, ScalaModule}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
 case class IntrospectorStateHolder(valueLong: Option[Long])
 
 /**
@@ -50,6 +52,77 @@ class ScalaAnnotationIntrospectorStateSpec extends AnyWordSpec with Matchers {
         builder.scalaAnnotationIntrospectorModule.clearRegisteredReferencedTypes()
       }
     }
+    // introspecting a class registers what it derived, on whatever thread first deserializes it, so
+    // registrations are made concurrently now rather than once at startup from one thread
+    "keep every registration made from many threads at once" in {
+      val module = ScalaAnnotationIntrospectorModule.newStandaloneInstance()
+      val threads = 8
+      val perThread = 250
+      val pool = Executors.newFixedThreadPool(threads)
+      val start = new CountDownLatch(1)
+      try {
+        (0 until threads).foreach { t =>
+          pool.execute(new Runnable {
+            override def run(): Unit = {
+              start.await()
+              (0 until perThread).foreach { i =>
+                module.registerReferencedValueType(classOf[IntrospectorStateHolder], s"field-$t-$i", classOf[Long])
+              }
+            }
+          })
+        }
+        start.countDown()
+        pool.shutdown()
+        pool.awaitTermination(60, TimeUnit.SECONDS) shouldBe true
+        val missing = for {
+          t <- 0 until threads
+          i <- 0 until perThread
+          if module.getRegisteredReferencedValueType(classOf[IntrospectorStateHolder], s"field-$t-$i").isEmpty
+        } yield s"field-$t-$i"
+        withClue(s"${missing.size} of ${threads * perThread} registrations were lost: ") {
+          missing shouldBe empty
+        }
+      } finally {
+        pool.shutdownNow()
+        module.clearRegisteredReferencedTypes()
+      }
+    }
+
+    "keep registrations for different classes made from many threads at once" in {
+      val module = ScalaAnnotationIntrospectorModule.newStandaloneInstance()
+      val classes = Seq(classOf[IntrospectorStateHolder], classOf[String], classOf[Integer], classOf[java.lang.Long])
+      val threads = 8
+      val pool = Executors.newFixedThreadPool(threads)
+      val start = new CountDownLatch(1)
+      try {
+        (0 until threads).foreach { t =>
+          pool.execute(new Runnable {
+            override def run(): Unit = {
+              start.await()
+              (0 until 250).foreach { i =>
+                classes.foreach(c => module.registerReferencedValueType(c, s"field-$t-$i", classOf[Long]))
+              }
+            }
+          })
+        }
+        start.countDown()
+        pool.shutdown()
+        pool.awaitTermination(60, TimeUnit.SECONDS) shouldBe true
+        val missing = for {
+          c <- classes
+          t <- 0 until threads
+          i <- 0 until 250
+          if module.getRegisteredReferencedValueType(c, s"field-$t-$i").isEmpty
+        } yield s"${c.getName}.field-$t-$i"
+        withClue(s"${missing.size} registrations were lost: ") {
+          missing shouldBe empty
+        }
+      } finally {
+        pool.shutdownNow()
+        module.clearRegisteredReferencedTypes()
+      }
+    }
+
     "still recognise the module object when removing it from a builder" in {
       val builder = ScalaModule.builder().addAllBuiltinModules()
       builder.hasModule(ScalaAnnotationIntrospectorModule) shouldEqual true


### PR DESCRIPTION
`overrideMap` was a plain `scala.collection.mutable.HashMap`:

```scala
private[introspect] val overrideMap = MutableMap[String, ClassOverrides]()
```

That was enough while registering a referenced value type was something an application did at startup, from one thread, before any mapper was used. Since #841 it is not: `_descriptorFor` calls `registerDerivedReferencedValueTypes` on every descriptor-cache miss, so introspecting a class registers what it captured by deriving `ScalaTypeInfo` — on whatever application thread first deserializes it, and again for every class whose descriptor has since been evicted, which the default cache of 100 makes routine.

Read and written that way a `HashMap` loses entries, and a reader can be left walking a bucket chain that a resize is halfway through moving. It is a `TrieMap` now, as is the per-class map inside `ClassOverrides`, which is written the same way.

## Kept as an implementation detail

Both keep the type they were declared as (`mutable.Map`), so the accessors are unchanged and MiMa is clean with no filters. My first attempt declared `overrideMap` as `TrieMap` and MiMa rejected it on all three Scala versions — a changed result type plus two new interface methods — which is worth knowing if anyone is tempted to tighten the type later.

I also wrote a `putIfAbsent` helper on the assumption that `TrieMap.getOrElseUpdate` only became atomic in 2.13. That was wrong: 2.12.21's `TrieMap` overrides it too, inserting under `KEY_ABSENT` and handing back the winner's value, so the plain `getOrElseUpdate` the code already used is safe on every version cross-built here. The helper is gone.

## Volatile

`_descriptorCache`, `_scalaTypeCache` and `_derivedTypeInfo` are `@volatile` now. `setLookupCacheFactory` and `setDescriptorCacheSize` replace them outright, and without it a thread could go on reading the instance they replaced. `SealedPolymorphism` and `Scala3EnumInfo` already mark their equivalents this way.

## Not bounded

The original analysis also called this map unbounded. Left that way deliberately — it is a registry rather than a cache, and evicting from it would silently drop what an application registered through the public `registerReferencedValueType`.

## Tests

Two cases in `ScalaAnnotationIntrospectorStateSpec`: 8 threads registering 250 fields each on one class, and the same across four classes at once, both asserting every registration is readable afterwards.

Run three times against the unfixed sources — **failed all three**, losing 65, 68 and 92 of 2000 registrations in the first, and 217, 222 and 305 in the second. Run three times with the fix — passed all three, nothing lost. So this reproduces reliably rather than being a theoretical race.

Scala 2.12.21: 663 passed. Scala 2.13.18: 671 passed. Scala 3.3.8: 752 passed. MiMa clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)